### PR TITLE
dev-host: /test/project UI + persistent mcp-project-manager

### DIFF
--- a/sites/a1-idc1/test/project/app.js
+++ b/sites/a1-idc1/test/project/app.js
@@ -1,0 +1,295 @@
+const $ = (id) => document.getElementById(id);
+
+const backendStatus = $('backendStatus');
+const refreshBtn = $('refreshBtn');
+const filterInput = $('filterInput');
+const toolSelect = $('toolSelect');
+const argsInput = $('argsInput');
+const callBtn = $('callBtn');
+const copyBtn = $('copyBtn');
+const resultEl = $('result');
+const statusEl = $('status');
+
+const pmPrefixEl = $('pmPrefix');
+const pmToolCountEl = $('pmToolCount');
+const pmStatusEl = $('pmStatus');
+const pmListTasksBtn = $('pmListTasksBtn');
+const pmLoadListTasksBtn = $('pmLoadListTasksBtn');
+const pmCreateTaskBtn = $('pmCreateTaskBtn');
+const pmLoadCreateTaskBtn = $('pmLoadCreateTaskBtn');
+const pmTitle = $('pmTitle');
+const pmDescription = $('pmDescription');
+const pmPriority = $('pmPriority');
+const pmTaskStatus = $('pmTaskStatus');
+
+let allTools = [];
+
+let pmTools = [];
+let pmPrefix = '';
+
+const setStatus = (text) => {
+  statusEl.textContent = text;
+};
+
+const setPmStatus = (text) => {
+  if (pmStatusEl) pmStatusEl.textContent = text;
+};
+
+const pretty = (value) => {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+
+const detectProjectManagerTools = () => {
+  pmTools = allTools.filter((tool) => {
+    const name = (tool?.name || '').toLowerCase();
+    return name.includes('project') || name.includes('project-manager') || name.includes('pm');
+  });
+
+  const prefixes = new Map();
+  for (const tool of pmTools) {
+    const name = tool?.name || '';
+    const idx = name.indexOf('_');
+    const prefix = idx > 0 ? name.slice(0, idx) : '';
+    if (prefix) prefixes.set(prefix, (prefixes.get(prefix) || 0) + 1);
+  }
+
+  let best = '';
+  let bestCount = 0;
+  for (const [key, value] of prefixes.entries()) {
+    if (value > bestCount) {
+      best = key;
+      bestCount = value;
+    }
+  }
+
+  pmPrefix = best;
+  if (pmPrefixEl) pmPrefixEl.textContent = pmPrefix || '(unknown)';
+  if (pmToolCountEl) pmToolCountEl.textContent = String(pmTools.length);
+
+  const enabled = pmTools.length > 0;
+  if (pmListTasksBtn) pmListTasksBtn.disabled = !enabled;
+  if (pmLoadListTasksBtn) pmLoadListTasksBtn.disabled = !enabled;
+  if (pmCreateTaskBtn) pmCreateTaskBtn.disabled = !enabled;
+  if (pmLoadCreateTaskBtn) pmLoadCreateTaskBtn.disabled = !enabled;
+
+  setPmStatus(enabled ? 'Ready.' : 'No Project Manager tools detected yet.');
+};
+
+const findToolByHint = (hints) => {
+  const candidates = pmTools.length ? pmTools : allTools;
+  const normalizedHints = (hints || []).map((h) => String(h || '').toLowerCase()).filter(Boolean);
+  for (const tool of candidates) {
+    const name = (tool?.name || '').toLowerCase();
+    if (normalizedHints.every((hint) => name.includes(hint))) {
+      return tool?.name || '';
+    }
+  }
+  return '';
+};
+
+const loadIntoEditor = ({ name, args }) => {
+  if (name) {
+    toolSelect.value = name;
+  }
+  argsInput.value = pretty(args || {});
+};
+
+const updateToolOptions = () => {
+  const filter = (filterInput.value || '').trim().toLowerCase();
+  const tools = filter
+    ? allTools.filter((tool) => (tool?.name || '').toLowerCase().includes(filter))
+    : allTools;
+
+  toolSelect.innerHTML = '';
+  tools.forEach((tool) => {
+    const opt = document.createElement('option');
+    opt.value = tool.name;
+    opt.textContent = tool.name;
+    toolSelect.appendChild(opt);
+  });
+
+  if (!tools.length) {
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.textContent = '(no tools found)';
+    toolSelect.appendChild(opt);
+  }
+};
+
+const fetchTools = async () => {
+  setStatus('Fetching tools…');
+  backendStatus.textContent = 'Loading…';
+  refreshBtn.disabled = true;
+  callBtn.disabled = true;
+
+  try {
+    const response = await fetch('/test/project/api/tools');
+    const data = await response.json();
+    if (!response.ok) {
+      backendStatus.textContent = 'Error';
+      resultEl.textContent = pretty(data);
+      setStatus(`Failed to fetch tools (HTTP ${response.status}).`);
+      return;
+    }
+
+    allTools = Array.isArray(data?.tools) ? data.tools : [];
+    backendStatus.textContent = 'OK';
+    updateToolOptions();
+    detectProjectManagerTools();
+    setStatus(`Loaded ${allTools.length} tool(s).`);
+    resultEl.textContent = pretty(data);
+  } catch (err) {
+    backendStatus.textContent = 'Error';
+    resultEl.textContent = pretty({ error: err?.message || String(err) });
+    setStatus('Failed to fetch tools (network error).');
+  } finally {
+    refreshBtn.disabled = false;
+    callBtn.disabled = false;
+  }
+};
+
+const callTool = async () => {
+  const name = toolSelect.value;
+  if (!name) {
+    setStatus('Select a tool first.');
+    return;
+  }
+
+  let args = {};
+  try {
+    const raw = (argsInput.value || '').trim();
+    args = raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    setStatus(`Arguments JSON invalid: ${err?.message || String(err)}`);
+    return;
+  }
+
+  setStatus(`Calling ${name}…`);
+  callBtn.disabled = true;
+
+  try {
+    const response = await fetch('/test/project/api/call', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name, arguments: args })
+    });
+    const data = await response.json();
+    resultEl.textContent = pretty(data);
+    if (!response.ok) {
+      setStatus(`Tool call failed (HTTP ${response.status}).`);
+      return;
+    }
+    setStatus('Done.');
+  } catch (err) {
+    resultEl.textContent = pretty({ error: err?.message || String(err) });
+    setStatus('Tool call failed (network error).');
+  } finally {
+    callBtn.disabled = false;
+  }
+};
+
+const buildCreateTaskArgs = () => {
+  const title = (pmTitle?.value || '').trim();
+  const description = (pmDescription?.value || '').trim();
+  const priorityValue = (pmPriority?.value || '').trim();
+  const statusValue = (pmTaskStatus?.value || '').trim();
+
+  const args = {};
+  if (title) args.title = title;
+  if (description) args.description = description;
+  if (priorityValue) args.priority = priorityValue;
+  if (statusValue) args.status = statusValue;
+
+  return args;
+};
+
+const wirePmButtons = () => {
+  const callViaApi = async ({ name, args }) => {
+    toolSelect.value = name;
+    argsInput.value = pretty(args || {});
+    await callTool();
+  };
+
+  const listToolName = () => findToolByHint(['list', 'tasks']) || findToolByHint(['tasks', 'list']);
+  const createToolName = () => findToolByHint(['create', 'task']) || findToolByHint(['task', 'create']);
+
+  if (pmListTasksBtn) {
+    pmListTasksBtn.disabled = true;
+    pmListTasksBtn.addEventListener('click', async () => {
+      const toolName = listToolName();
+      if (!toolName) {
+        setPmStatus('Could not find a list-tasks tool. Use the generic tool list below.');
+        return;
+      }
+      setPmStatus(`Calling ${toolName}…`);
+      await callViaApi({ name: toolName, args: {} });
+      setPmStatus('Done.');
+    });
+  }
+
+  if (pmLoadListTasksBtn) {
+    pmLoadListTasksBtn.disabled = true;
+    pmLoadListTasksBtn.addEventListener('click', () => {
+      const toolName = listToolName();
+      if (!toolName) {
+        setPmStatus('Could not find a list-tasks tool.');
+        return;
+      }
+      loadIntoEditor({ name: toolName, args: {} });
+      setPmStatus('Loaded into editor.');
+    });
+  }
+
+  if (pmCreateTaskBtn) {
+    pmCreateTaskBtn.disabled = true;
+    pmCreateTaskBtn.addEventListener('click', async () => {
+      const toolName = createToolName();
+      if (!toolName) {
+        setPmStatus('Could not find a create-task tool. Use the generic tool list below.');
+        return;
+      }
+      const args = buildCreateTaskArgs();
+      if (!Object.keys(args).length) {
+        setPmStatus('Provide at least a Title.');
+        return;
+      }
+      setPmStatus(`Calling ${toolName}…`);
+      await callViaApi({ name: toolName, args });
+      setPmStatus('Done.');
+    });
+  }
+
+  if (pmLoadCreateTaskBtn) {
+    pmLoadCreateTaskBtn.disabled = true;
+    pmLoadCreateTaskBtn.addEventListener('click', () => {
+      const toolName = createToolName();
+      if (!toolName) {
+        setPmStatus('Could not find a create-task tool.');
+        return;
+      }
+      const args = buildCreateTaskArgs();
+      loadIntoEditor({ name: toolName, args });
+      setPmStatus('Loaded into editor.');
+    });
+  }
+};
+
+refreshBtn.addEventListener('click', fetchTools);
+filterInput.addEventListener('input', updateToolOptions);
+callBtn.addEventListener('click', callTool);
+copyBtn.addEventListener('click', async () => {
+  try {
+    await navigator.clipboard.writeText(resultEl.textContent || '');
+    setStatus('Copied result.');
+  } catch {
+    setStatus('Copy failed.');
+  }
+});
+
+fetchTools();
+
+wirePmButtons();

--- a/sites/a1-idc1/test/project/index.html
+++ b/sites/a1-idc1/test/project/index.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Project tools playground</title>
+    <link rel="stylesheet" href="/test/project/styles.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <header class="hero">
+        <div>
+          <p class="eyebrow">Surf Thailand • MCP</p>
+          <h1>Project Manager + MCP tools</h1>
+          <p class="lede">
+            Simple UI that lists tools and calls them via the dev-host proxy at <code>/test/project/api</code>.
+          </p>
+        </div>
+        <div class="hero-meta">
+          <div class="meta-chip">
+            <span>Backend</span>
+            <strong id="backendStatus">Checking…</strong>
+          </div>
+        </div>
+      </header>
+
+      <section class="panel">
+        <div class="card" id="pmCard">
+          <div class="card-head">
+            <h2>Project Manager</h2>
+            <p class="muted">Quick actions powered by <code>mcp-project-manager</code> (auto-detected from <code>tools/list</code>).</p>
+          </div>
+
+          <div class="row">
+            <div class="meta-chip wide">
+              <span>Detected tool prefix</span>
+              <strong id="pmPrefix">—</strong>
+            </div>
+            <div class="meta-chip wide">
+              <span>Detected PM tools</span>
+              <strong id="pmToolCount">—</strong>
+            </div>
+          </div>
+
+          <div class="pm-grid">
+            <div class="pm-actions">
+              <h3>Quick actions</h3>
+              <div class="row wrap">
+                <button id="pmListTasksBtn" type="button">List tasks</button>
+                <button id="pmLoadListTasksBtn" type="button" class="secondary">Load args into editor</button>
+              </div>
+              <div class="row wrap">
+                <button id="pmCreateTaskBtn" type="button">Create task</button>
+                <button id="pmLoadCreateTaskBtn" type="button" class="secondary">Load args into editor</button>
+              </div>
+              <div id="pmStatus" class="status">Waiting for tools…</div>
+            </div>
+
+            <div class="pm-form">
+              <h3>Create task</h3>
+              <label class="field">
+                <span>Title</span>
+                <input id="pmTitle" type="text" placeholder="e.g. Implement /test/project UI" />
+              </label>
+              <label class="field">
+                <span>Description</span>
+                <textarea id="pmDescription" rows="5" placeholder="Optional details"></textarea>
+              </label>
+              <div class="two-col">
+                <label class="field">
+                  <span>Priority</span>
+                  <select id="pmPriority">
+                    <option value="">(default)</option>
+                    <option value="low">low</option>
+                    <option value="medium">medium</option>
+                    <option value="high">high</option>
+                  </select>
+                </label>
+                <label class="field">
+                  <span>Status</span>
+                  <select id="pmTaskStatus">
+                    <option value="">(default)</option>
+                    <option value="todo">todo</option>
+                    <option value="in_progress">in_progress</option>
+                    <option value="blocked">blocked</option>
+                    <option value="done">done</option>
+                  </select>
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="card-head">
+            <h2>Tools</h2>
+            <p class="muted">Fetched from 1mcp via <code>tools/list</code>.</p>
+          </div>
+          <div class="row">
+            <button id="refreshBtn" type="button">Refresh tools</button>
+            <input id="filterInput" type="text" placeholder="filter (e.g. project, pm, imagen)" />
+          </div>
+          <div class="grid">
+            <div>
+              <label class="field">
+                <span>Tool</span>
+                <select id="toolSelect"></select>
+              </label>
+              <label class="field">
+                <span>Arguments (JSON)</span>
+                <textarea id="argsInput" rows="10" spellcheck="false">{}</textarea>
+              </label>
+              <div class="row">
+                <button id="callBtn" type="button">Call tool</button>
+                <button id="copyBtn" type="button" class="secondary">Copy result</button>
+              </div>
+              <div id="status" class="status">Ready.</div>
+            </div>
+            <div>
+              <label class="field">
+                <span>Result</span>
+                <pre id="result" class="output">// waiting…</pre>
+              </label>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <small>
+          Tip: Once <code>mcp-project-manager</code> is registered in 1mcp, its tools should appear here.
+        </small>
+      </footer>
+    </main>
+
+    <script type="module" src="/test/project/app.js"></script>
+  </body>
+</html>

--- a/sites/a1-idc1/test/project/styles.css
+++ b/sites/a1-idc1/test/project/styles.css
@@ -1,0 +1,224 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b1020;
+  --card: rgba(255, 255, 255, 0.06);
+  --border: rgba(255, 255, 255, 0.12);
+  --text: rgba(255, 255, 255, 0.92);
+  --muted: rgba(255, 255, 255, 0.66);
+  --accent: #6ee7ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: radial-gradient(circle at 20% 0%, rgba(110, 231, 255, 0.25), transparent 60%),
+    radial-gradient(circle at 90% 10%, rgba(196, 134, 255, 0.25), transparent 55%), var(--bg);
+  color: var(--text);
+}
+
+.shell {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 28px 18px 48px;
+}
+
+.hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.lede {
+  margin-top: 10px;
+  color: var(--muted);
+  max-width: 62ch;
+}
+
+.hero-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.meta-chip {
+  border: 1px solid var(--border);
+  background: var(--card);
+  padding: 10px 12px;
+  border-radius: 12px;
+  min-width: 160px;
+}
+
+.meta-chip.wide {
+  min-width: 220px;
+}
+
+.meta-chip span {
+  display: block;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.panel {
+  margin-top: 14px;
+}
+
+.card {
+  border: 1px solid var(--border);
+  background: var(--card);
+  border-radius: 16px;
+  padding: 18px;
+}
+
+.card-head h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.card-head p {
+  margin: 8px 0 0;
+  color: var(--muted);
+}
+
+.row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-top: 14px;
+}
+
+.row.wrap {
+  flex-wrap: wrap;
+}
+
+.row input {
+  flex: 1;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.pm-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.pm-actions h3,
+.pm-form h3 {
+  margin: 0;
+  font-size: 14px;
+  letter-spacing: 0.02em;
+  color: rgba(255, 255, 255, 0.84);
+}
+
+.pm-actions .row {
+  margin-top: 12px;
+}
+
+.two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.field {
+  display: block;
+  margin-bottom: 12px;
+}
+
+.field span {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+select,
+input,
+textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--text);
+  padding: 10px 12px;
+  border-radius: 12px;
+  font-size: 14px;
+}
+
+textarea {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+button {
+  border: 1px solid var(--border);
+  background: rgba(110, 231, 255, 0.14);
+  color: var(--text);
+  padding: 10px 14px;
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+button.secondary {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.status {
+  margin-top: 10px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.output {
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 12px;
+  padding: 12px;
+  overflow: auto;
+  min-height: 380px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.footer {
+  margin-top: 18px;
+  color: var(--muted);
+}
+
+@media (max-width: 880px) {
+  .hero {
+    flex-direction: column;
+  }
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .pm-grid {
+    grid-template-columns: 1fr;
+  }
+  .two-col {
+    grid-template-columns: 1fr;
+  }
+}

--- a/stacks/pc1-stack/1mcp-dev.json
+++ b/stacks/pc1-stack/1mcp-dev.json
@@ -67,6 +67,19 @@
       "url": "http://pc1.vpn:8020/mcp",
       "tags": ["pc1", "imagen", "sdxl", "dev"],
       "enabled": true
+    },
+    "mcp-project-manager": {
+      "command": "npx",
+      "args": ["-y", "mcp-project-manager"],
+      "env": {
+        "MCP_TASK_DATA_DIR": "/data/pm"
+      },
+      "tags": ["pc1", "project", "pm", "dev"],
+      "connectionTimeout": 60000,
+      "requestTimeout": 60000,
+      "restartOnExit": true,
+      "restartDelay": 1000,
+      "enabled": true
     }
   }
 }

--- a/stacks/pc1-stack/1mcp-hub.json
+++ b/stacks/pc1-stack/1mcp-hub.json
@@ -83,6 +83,19 @@
       "url": "http://pc1.vpn:8046/mcp",
       "tags": ["pc1", "agents"],
       "enabled": true
+    },
+    "mcp-project-manager": {
+      "command": "npx",
+      "args": ["-y", "mcp-project-manager"],
+      "env": {
+        "MCP_TASK_DATA_DIR": "/data/pm"
+      },
+      "tags": ["pc1", "project", "pm"],
+      "connectionTimeout": 60000,
+      "requestTimeout": 60000,
+      "restartOnExit": true,
+      "restartDelay": 1000,
+      "enabled": true
     }
   }
 }

--- a/stacks/pc1-stack/docker-compose.yml
+++ b/stacks/pc1-stack/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /mnt/wsl/docker-desktop/run/docker.sock:/var/run/docker-desktop.sock:ro
       - docker-mcp-venv:/opt/docker-mcp-venv
+      - mcp-project-manager-data:/data/pm
 
   1mcp-agent-dev:
     <<: *default-service
@@ -92,6 +93,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /mnt/wsl/docker-desktop/run/docker.sock:/var/run/docker-desktop.sock:ro
       - docker-mcp-venv:/opt/docker-mcp-venv
+      - mcp-project-manager-data:/data/pm
 
   mcp-agents:
     <<: *default-service
@@ -388,6 +390,7 @@ networks:
 
 volumes:
   docker-mcp-venv:
+  mcp-project-manager-data:
   stack-sqlite:
   authentik-media:
   authentik-templates:


### PR DESCRIPTION
## Summary
- Add /test/project SPA under dev-host for testing MCP tools, with Project Manager quick actions.
- Add dev-host API endpoints /test/project/api/tools and /test/project/api/call that talk to 1mcp.
- Register mcp-project-manager as a 1mcp stdio server (npx) with MCP_TASK_DATA_DIR=/data/pm.
- Add named volume mcp-project-manager-data mounted into 1mcp-agent containers at /data/pm for persistence.

## Test Plan
- Open http://dev-host.pc1/test/project/ and confirm tools load.
- Confirm PM tools show up after 1mcp restart.
- Use quick actions (List tasks / Create task) and verify persistence across restart.
