### PR TITLE
feat: Portainer monitoring + MCP integration

### DIFF
--- a/sites/idc1/config/Caddyfile
+++ b/sites/idc1/config/Caddyfile
@@ -98,3 +98,16 @@ deka.idc1.surf-thailand.com {
         output file /var/log/caddy/deka.idc1.access.log
     }
 }
+
+portainer.idc1.surf-thailand.com {
+    encode gzip zstd
+
+    @vpn_only not remote_ip 10.8.0.0/24 127.0.0.1
+    respond @vpn_only 403
+
+    reverse_proxy http://127.0.0.1:9000
+
+    log {
+        output file /var/log/caddy/portainer.idc1.access.log
+    }
+}

--- a/stacks/idc1-portainer/.env.example
+++ b/stacks/idc1-portainer/.env.example
@@ -1,0 +1,5 @@
+# idc1-portainer environment template
+# Copy to .env (kept out of git)
+
+# Bind Portainer UI to localhost only; expose via idc1 Caddy
+PORTAINER_HTTP_PORT=9000

--- a/stacks/idc1-portainer/docker-compose.yml
+++ b/stacks/idc1-portainer/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+  portainer:
+    image: portainer/portainer-ce:2.21.5
+    container_name: idc1-portainer
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:${PORTAINER_HTTP_PORT:-9000}:9000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+
+volumes:
+  portainer_data:

--- a/stacks/idc1-stack/.env.example
+++ b/stacks/idc1-stack/.env.example
@@ -35,6 +35,14 @@ ONE_MCP_CONFIG_FILE=./1mcp.json
 ONE_MCP_EXTERNAL_URL=http://127.0.0.1:${ONE_MCP_PORT}
 ONE_MCP_WORKSPACE_HOST_DIR=../../
 
+# Portainer MCP (used by 1mcp-agent to talk to Portainer)
+# You must create a Portainer admin API token in the Portainer UI.
+PORTAINER_HTTP_PORT=9000
+PORTAINER_SERVER=host.docker.internal:${PORTAINER_HTTP_PORT}
+PORTAINER_TOKEN=__REPLACE_ME__
+PORTAINER_READ_ONLY=1
+PORTAINER_DISABLE_VERSION_CHECK=0
+
 # MCP LINE
 MCP_LINE_BUILD_CONTEXT=../../mcp/mcp-line
 MCP_LINE_PORT=8088

--- a/stacks/idc1-stack/1mcp-agent/Dockerfile
+++ b/stacks/idc1-stack/1mcp-agent/Dockerfile
@@ -18,10 +18,20 @@ RUN mkdir -p /etc/apt/keyrings \
   && apt-get install -y --no-install-recommends nodejs \
   && rm -rf /var/lib/apt/lists/*
 
-COPY mcp-tasks/stacks/idc1-stack/1mcp-agent/docker-mcp-stdio.sh /usr/local/bin/docker-mcp-stdio
+COPY docker-mcp-stdio.sh /usr/local/bin/docker-mcp-stdio
 RUN chmod +x /usr/local/bin/docker-mcp-stdio
 
 RUN npm install -g corepack && corepack enable
+
+# Install portainer-mcp (MCP server for Portainer)
+RUN curl -fsSL -o /tmp/portainer-mcp.tar.gz \
+    https://github.com/portainer/portainer-mcp/releases/download/v0.6.0/portainer-mcp-v0.6.0-linux-amd64.tar.gz \
+  && tar -xzf /tmp/portainer-mcp.tar.gz -C /usr/local/bin \
+  && rm -f /tmp/portainer-mcp.tar.gz \
+  && chmod +x /usr/local/bin/portainer-mcp
+
+COPY portainer-mcp-stdio.sh /usr/local/bin/portainer-mcp-stdio
+RUN chmod +x /usr/local/bin/portainer-mcp-stdio
 
 # Build 1MCP from local source (requires docker-compose build.context = C:\chaba_wt)
 COPY voyant/1mcp-agent-src /opt/1mcp-agent-src

--- a/stacks/idc1-stack/1mcp-agent/portainer-mcp-stdio.sh
+++ b/stacks/idc1-stack/1mcp-agent/portainer-mcp-stdio.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${PORTAINER_SERVER:-}" ]; then
+  echo "PORTAINER_SERVER is required (example: 127.0.0.1:9000)" >&2
+  exit 1
+fi
+
+if [ -z "${PORTAINER_TOKEN:-}" ]; then
+  echo "PORTAINER_TOKEN is required (Portainer admin API token)" >&2
+  exit 1
+fi
+
+TOOLS_PATH="${PORTAINER_TOOLS_PATH:-/tmp/portainer-tools.yaml}"
+
+ARGS=(
+  -server "${PORTAINER_SERVER}"
+  -token "${PORTAINER_TOKEN}"
+  -tools "${TOOLS_PATH}"
+)
+
+if [ "${PORTAINER_DISABLE_VERSION_CHECK:-0}" = "1" ]; then
+  ARGS+=( -disable-version-check )
+fi
+
+if [ "${PORTAINER_READ_ONLY:-1}" = "1" ]; then
+  ARGS+=( -read-only )
+fi
+
+exec /usr/local/bin/portainer-mcp "${ARGS[@]}"

--- a/stacks/idc1-stack/1mcp.json
+++ b/stacks/idc1-stack/1mcp.json
@@ -9,6 +9,15 @@
       "restartDelay": 2000,
       "enabled": true
     },
+    "portainer": {
+      "command": "portainer-mcp-stdio",
+      "tags": ["portainer", "docker"],
+      "connectionTimeout": 120000,
+      "requestTimeout": 120000,
+      "restartOnExit": true,
+      "restartDelay": 2000,
+      "enabled": true
+    },
     "mcp-devops": {
       "transport": "streamableHttp",
       "url": "http://mcp-devops:8425/mcp",

--- a/stacks/idc1-stack/docker-compose.yml
+++ b/stacks/idc1-stack/docker-compose.yml
@@ -83,6 +83,8 @@ services:
       context: ./1mcp-agent
     ports:
       - "127.0.0.1:${ONE_MCP_PORT:-3050}:${ONE_MCP_PORT:-3050}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       ONE_MCP_HOST: ${ONE_MCP_HOST:-0.0.0.0}
       ONE_MCP_PORT: ${ONE_MCP_PORT:-3050}
@@ -90,6 +92,10 @@ services:
       ONE_MCP_ENABLE_AUTH: "true"
       ONE_MCP_LOG_LEVEL: ${ONE_MCP_LOG_LEVEL:-info}
       ONE_MCP_CONFIG: ${ONE_MCP_CONFIG:-/root/.config/1mcp/mcp.json}
+      PORTAINER_SERVER: ${PORTAINER_SERVER:-host.docker.internal:${PORTAINER_HTTP_PORT:-9000}}
+      PORTAINER_TOKEN: ${PORTAINER_TOKEN:-}
+      PORTAINER_READ_ONLY: ${PORTAINER_READ_ONLY:-1}
+      PORTAINER_DISABLE_VERSION_CHECK: ${PORTAINER_DISABLE_VERSION_CHECK:-0}
       UV_PYTHON: python3
       UV_PYTHON_DOWNLOADS: never
       UV_PROJECT_ENVIRONMENT: /tmp/uv-project

--- a/stacks/pc1-portainer-agent/.env.example
+++ b/stacks/pc1-portainer-agent/.env.example
@@ -1,0 +1,5 @@
+# pc1-portainer-agent environment template
+# Copy to .env (kept out of git)
+
+PC1_VPN_IP=10.8.0.11
+PORTAINER_AGENT_PORT=9001

--- a/stacks/pc1-portainer-agent/docker-compose.yml
+++ b/stacks/pc1-portainer-agent/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+
+services:
+  portainer-agent:
+    image: portainer/agent:2.21.5
+    container_name: pc1-portainer-agent
+    restart: unless-stopped
+    ports:
+      - "${PC1_VPN_IP:-10.8.0.11}:${PORTAINER_AGENT_PORT:-9001}:9001"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker/volumes:/var/lib/docker/volumes

--- a/stacks/pc2-portainer-agent/.env.example
+++ b/stacks/pc2-portainer-agent/.env.example
@@ -1,0 +1,5 @@
+# pc2-portainer-agent environment template
+# Copy to .env (kept out of git)
+
+PC2_VPN_IP=10.8.0.12
+PORTAINER_AGENT_PORT=9001

--- a/stacks/pc2-portainer-agent/docker-compose.yml
+++ b/stacks/pc2-portainer-agent/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+
+services:
+  portainer-agent:
+    image: portainer/agent:2.21.5
+    container_name: pc2-portainer-agent
+    restart: unless-stopped
+    ports:
+      - "${PC2_VPN_IP:-10.8.0.12}:${PORTAINER_AGENT_PORT:-9001}:9001"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker/volumes:/var/lib/docker/volumes


### PR DESCRIPTION
## Summary\n- Add Portainer CE UI stack for idc1 (localhost bind)\n- Add Portainer agent stacks for pc1/pc2 (VPN bind)\n- Add idc1 Caddy vhost portainer.idc1.surf-thailand.com (VPN-only)\n- Add portainer-mcp v0.6.0 into idc1 1mcp-agent + wrapper + 1mcp.json registration\n\n## Notes\n- PORTAINER_TOKEN must be created in Portainer UI and set in stacks/idc1-stack/.env\n- portainer-mcp uses PORTAINER_SERVER as host:port (no scheme)\n