### PR TITLE
chore(idc1-vpn): forward VPN tcp 80/443 to host

### DIFF
--- a/stacks/idc1-vpn/docker-compose.yml
+++ b/stacks/idc1-vpn/docker-compose.yml
@@ -34,11 +34,23 @@ services:
       WG_POST_UP: >-
         iptables -t nat -A PREROUTING -i wg0 -p tcp --dport 22 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:22;
         iptables -A FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j ACCEPT;
-        iptables -t nat -A POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j MASQUERADE
+        iptables -t nat -A POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j MASQUERADE;
+        iptables -t nat -A PREROUTING -i wg0 -p tcp --dport 80 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:80;
+        iptables -A FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 80 -j ACCEPT;
+        iptables -t nat -A POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 80 -j MASQUERADE;
+        iptables -t nat -A PREROUTING -i wg0 -p tcp --dport 443 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:443;
+        iptables -A FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 443 -j ACCEPT;
+        iptables -t nat -A POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 443 -j MASQUERADE
       WG_POST_DOWN: >-
         iptables -t nat -D PREROUTING -i wg0 -p tcp --dport 22 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:22 || true;
         iptables -D FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j ACCEPT || true;
-        iptables -t nat -D POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j MASQUERADE || true
+        iptables -t nat -D POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j MASQUERADE || true;
+        iptables -t nat -D PREROUTING -i wg0 -p tcp --dport 80 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:80 || true;
+        iptables -D FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 80 -j ACCEPT || true;
+        iptables -t nat -D POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 80 -j MASQUERADE || true;
+        iptables -t nat -D PREROUTING -i wg0 -p tcp --dport 443 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:443 || true;
+        iptables -D FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 443 -j ACCEPT || true;
+        iptables -t nat -D POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 443 -j MASQUERADE || true
       PASSWORD: ${WG_EASY_PASSWORD:-}
     volumes:
       - wg-easy-data:/etc/wireguard


### PR DESCRIPTION
## Why\nVPN clients resolve *.idc1.vpn to 10.8.0.1 (wg0), but TCP :80/:443 were not reachable because wg-easy was only DNAT'ing port 22 to the host gateway.\n\n## Change\n- Add WG_POST_UP / WG_POST_DOWN iptables rules to DNAT+FORWARD+MASQUERADE tcp 80 and tcp 443 to .\n\n## Result\n- VPN clients can reach Caddy/Portainer via http://portainer.idc1.vpn (tcp/80).\n