### PR TITLE
chore(portainer): bump to 2.31.2 and document ssh

### DIFF
--- a/docs/ssh.me
+++ b/docs/ssh.me
@@ -1,0 +1,6 @@
+# pc2 #
+ssh -i "$env:USERPROFILE\.ssh\chaba_ed25519" -o IdentitiesOnly=yes chaba@pc2.vpn
+ssh -i "$env:USERPROFILE\.ssh\chaba_ed25519" -o IdentitiesOnly=yes chaba@192.168.1.38
+
+# idc1 #
+ssh -i "$env:USERPROFILE\.ssh\chaba_ed25519" -o IdentitiesOnly=yes chaba@idc1.surf-thailand.com

--- a/stacks/idc1-portainer/docker-compose.yml
+++ b/stacks/idc1-portainer/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3.9"
-
 services:
   portainer:
-    image: portainer/portainer-ce:2.21.5
+    image: portainer/portainer-ce:2.31.2
     container_name: idc1-portainer
     restart: unless-stopped
     ports:


### PR DESCRIPTION
- Bump Portainer CE image to 2.31.2 in idc1-portainer stack\n- Remove unnecessary group_add\n- Add docs/ssh.me helper commands\n\nNotes:\n- Deploy this compose on idc1 host (not local Docker Desktop) to avoid port 9000 conflicts.