### PR TITLE
fix(idc1-vpn): add wildcard rewrites for *.vpn

### DIFF
--- a/stacks/idc1-vpn/config/coredns/Corefile
+++ b/stacks/idc1-vpn/config/coredns/Corefile
@@ -6,6 +6,9 @@
 }
 
 vpn:53 {
+    rewrite name regex (.*)\.pc1\.vpn pc1.vpn
+    rewrite name regex (.*)\.idc1\.vpn idc1.vpn
+    rewrite name regex (.*)\.pc2\.vpn pc2.vpn
     file /etc/coredns/zones/vpn.db vpn
     import vitals
 }


### PR DESCRIPTION
Adds CoreDNS rewrite rules in idc1-vpn so any subdomain under pc1/idc1/pc2 resolves to the base host (e.g. foo.pc1.vpn -> pc1.vpn). This matches docs and pc2-vpn behavior.