### PR TITLE
fix(pc2): keep 1mcp healthy (disable mcp-task, correct mcp-glama port)

### DIFF
--- a/stacks/pc2-stack/1mcp-hub.json
+++ b/stacks/pc2-stack/1mcp-hub.json
@@ -16,11 +16,11 @@
       "transport": "streamableHttp",
       "url": "http://mcp-task:8016/mcp",
       "tags": ["pc2", "task"],
-      "enabled": true
+      "enabled": false
     },
     "mcp-glama": {
       "transport": "streamableHttp",
-      "url": "http://mcp-glama:8014/mcp",
+      "url": "http://mcp-glama:7214/mcp",
       "tags": ["pc2", "ai"],
       "enabled": true
     },


### PR DESCRIPTION
pc2 1MCP /health was degraded due to unreachable upstreams:\n- mcp-task was configured at :8016 but not reachable\n- mcp-glama was configured at :8014 but the service is on :7214\n\nThis change disables mcp-task and corrects the mcp-glama URL to :7214.