### PR TITLE
idc1-vpn: don't DNAT peer SSH to server

### DIFF
--- a/stacks/idc1-vpn/docker-compose.yml
+++ b/stacks/idc1-vpn/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       WG_PERSISTENT_KEEPALIVE: ${WG_PERSISTENT_KEEPALIVE:-25}
       WG_EASY_HOST_GW: ${WG_EASY_HOST_GW:-172.20.0.1}
       WG_POST_UP: >-
-        iptables -t nat -A PREROUTING -i wg0 -p tcp --dport 22 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:22;
+        iptables -t nat -A PREROUTING -i wg0 -d 10.8.0.1 -p tcp --dport 22 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:22;
         iptables -A FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j ACCEPT;
         iptables -t nat -A POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j MASQUERADE;
         iptables -t nat -A PREROUTING -i wg0 -p tcp --dport 80 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:80;
@@ -42,7 +42,7 @@ services:
         iptables -A FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 443 -j ACCEPT;
         iptables -t nat -A POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 443 -j MASQUERADE
       WG_POST_DOWN: >-
-        iptables -t nat -D PREROUTING -i wg0 -p tcp --dport 22 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:22 || true;
+        iptables -t nat -D PREROUTING -i wg0 -d 10.8.0.1 -p tcp --dport 22 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:22 || true;
         iptables -D FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j ACCEPT || true;
         iptables -t nat -D POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j MASQUERADE || true;
         iptables -t nat -D PREROUTING -i wg0 -p tcp --dport 80 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:80 || true;


### PR DESCRIPTION
## What\nRestrict wg-easy SSH DNAT rule to only trigger for traffic destined to the VPN server IP (10.8.0.1).\n\n## Why\nCurrent WG_POST_UP DNAT rewrites any TCP/22 arriving on wg0 to the host gateway, which hijacks SSH to peers (e.g. 10.8.0.12). This change prevents that while keeping server SSH forwarding working for idc1.vpn.\n\n## Deploy\nOn idc1: cd ~/chaba/stacks/idc1-vpn && git pull && docker compose up -d --force-recreate wg-easy\n\n## Verify\nFrom VPN client: ssh chaba@10.8.0.1 hits idc1; ssh chaba@10.8.0.12 should hit pc2 (not idc1).