### PR TITLE
idc1-vpn: scope DNAT rules to server IP

### DIFF
--- a/stacks/idc1-vpn/docker-compose.yml
+++ b/stacks/idc1-vpn/docker-compose.yml
@@ -35,20 +35,20 @@ services:
         iptables -t nat -A PREROUTING -i wg0 -d 10.8.0.1 -p tcp --dport 22 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:22;
         iptables -A FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j ACCEPT;
         iptables -t nat -A POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j MASQUERADE;
-        iptables -t nat -A PREROUTING -i wg0 -p tcp --dport 80 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:80;
+        iptables -t nat -A PREROUTING -i wg0 -d 10.8.0.1 -p tcp --dport 80 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:80;
         iptables -A FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 80 -j ACCEPT;
         iptables -t nat -A POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 80 -j MASQUERADE;
-        iptables -t nat -A PREROUTING -i wg0 -p tcp --dport 443 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:443;
+        iptables -t nat -A PREROUTING -i wg0 -d 10.8.0.1 -p tcp --dport 443 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:443;
         iptables -A FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 443 -j ACCEPT;
         iptables -t nat -A POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 443 -j MASQUERADE
       WG_POST_DOWN: >-
         iptables -t nat -D PREROUTING -i wg0 -d 10.8.0.1 -p tcp --dport 22 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:22 || true;
         iptables -D FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j ACCEPT || true;
         iptables -t nat -D POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 22 -j MASQUERADE || true;
-        iptables -t nat -D PREROUTING -i wg0 -p tcp --dport 80 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:80 || true;
+        iptables -t nat -D PREROUTING -i wg0 -d 10.8.0.1 -p tcp --dport 80 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:80 || true;
         iptables -D FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 80 -j ACCEPT || true;
         iptables -t nat -D POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 80 -j MASQUERADE || true;
-        iptables -t nat -D PREROUTING -i wg0 -p tcp --dport 443 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:443 || true;
+        iptables -t nat -D PREROUTING -i wg0 -d 10.8.0.1 -p tcp --dport 443 -j DNAT --to-destination ${WG_EASY_HOST_GW:-172.20.0.1}:443 || true;
         iptables -D FORWARD -i wg0 -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 443 -j ACCEPT || true;
         iptables -t nat -D POSTROUTING -p tcp -d ${WG_EASY_HOST_GW:-172.20.0.1} --dport 443 -j MASQUERADE || true
       PASSWORD: ${WG_EASY_PASSWORD:-}


### PR DESCRIPTION
## What\nScope wg-easy DNAT (WG_POST_UP/WG_POST_DOWN) for ports 22/80/443 to destination 10.8.0.1 only.\n\n## Why\nWithout destination scoping, peer-destined connections (e.g. 10.8.0.12:22) get DNATed to the idc1 host gateway, making peer SSH land on idc1.\n\n## Deploy\nOn idc1: cd ~/chaba/stacks/idc1-vpn && git pull && docker compose up -d --force-recreate wg-easy\n\n## Verify\nFrom VPN client: ssh chaba@10.8.0.1 hits idc1; ssh chaba@10.8.0.12 hits pc2 (not idc1).