### PR TITLE
fix(idc1-assistance): playwright healthcheck

### DIFF
--- a/stacks/idc1-assistance/docker-compose.yml
+++ b/stacks/idc1-assistance/docker-compose.yml
@@ -2012,7 +2012,7 @@ services:
         fi
         npx @playwright/mcp@0.0.68 --host 0.0.0.0 --port 3050 --no-sandbox --allowed-hosts '*' --allowed-origins '*' --browser chromium --executable-path "$$CHROMIUM_BIN"
     healthcheck:
-      test: ["CMD-SHELL", "nc -z 127.0.0.1 3050 >/dev/null 2>&1 || exit 1"]
+      test: ["CMD-SHELL", "curl -sS http://127.0.0.1:3050/ | grep -q 'Invalid request' || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
Fixes idc1-assistance mcp-playwright container being marked unhealthy due to missing nc in Playwright image. Switch healthcheck to curl+grep 'Invalid request' (same as debug container).