### PR TITLE
fix(jarvis-frontend): poll /jarvis/api/status for lock screen

### DIFF
--- a/services/assistance/jarvis-frontend/App.tsx
+++ b/services/assistance/jarvis-frontend/App.tsx
@@ -1032,9 +1032,16 @@ export default function App() {
         setContainerStatusError("");
         let res: Response | null = null;
         try {
-          res = await fetch("/jarvis/status", { cache: "no-store" });
+          res = await fetch("/jarvis/api/status", { cache: "no-store" });
         } catch {
           res = null;
+        }
+        if (!res || !res.ok) {
+          try {
+            res = await fetch("/jarvis/status", { cache: "no-store" });
+          } catch {
+            res = null;
+          }
         }
         if (!res || !res.ok) {
           res = await fetch("/status", { cache: "no-store" });


### PR DESCRIPTION
Jarvis lock screen container status polling was hitting /jarvis/status (404). Poll /jarvis/api/status first; keep fallbacks.