### PR TITLE
Sys-kv routing instructions + macro registry injection

### DIFF
--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -1960,6 +1960,38 @@ async def _macro_tools_reload_selected_from_sheet(
     return {"ok": True, "mode": "by_name", "requested": want, "updated": updated, "missing": missing, "macros_count": len(cur)}
 
 
+def _macro_registry_text(*, macros: Any, max_items: int = 30) -> str:
+    if not isinstance(macros, dict) or not macros:
+        return ""
+    try:
+        lim = int(max_items)
+    except Exception:
+        lim = 30
+    lim = max(1, min(lim, 200))
+
+    # Keep compact: only name + description. The full tool schemas are already
+    # provided via function_declarations.
+    items: list[tuple[str, str]] = []
+    for k, v in macros.items():
+        name = str(k or "").strip()
+        if not name or not name.startswith("macro_"):
+            continue
+        desc = ""
+        if isinstance(v, dict):
+            desc = str(v.get("description") or "").strip()
+        items.append((name, desc))
+    items.sort(key=lambda t: t[0])
+    if not items:
+        return ""
+    out_lines: list[str] = []
+    for name, desc in items[:lim]:
+        if desc:
+            out_lines.append(f"- {name}: {desc}")
+        else:
+            out_lines.append(f"- {name}")
+    return "\n".join(out_lines).strip()
+
+
 def _macro_tools_cached_snapshot() -> dict[str, dict[str, Any]]:
     macros = _MACRO_TOOL_CACHE.get("macros")
     if isinstance(macros, dict):
@@ -15055,6 +15087,26 @@ async def ws_live(ws: WebSocket) -> None:
                 + "SYSTEM_INSTRUCTION (from system sheet; internal)\n"
                 + extra_sys
             )
+
+        # Macro registry (from macro sheet) to make NL routing tool-centric.
+        # This avoids hardcoded intent routing in code.
+        try:
+            sys_kv = getattr(ws.state, "sys_kv", None)
+            enabled = True
+            if isinstance(sys_kv, dict):
+                raw_enabled = str(sys_kv.get("system.macros.registry.enabled") or "").strip()
+                if raw_enabled:
+                    enabled = _parse_bool_cell(raw_enabled)
+                max_items = _safe_int(sys_kv.get("system.macros.registry.max_items"), default=30)
+            else:
+                max_items = 30
+            if enabled:
+                macros = await _macro_tools_get_cached(sys_kv=sys_kv if isinstance(sys_kv, dict) else None)
+                reg = _macro_registry_text(macros=macros, max_items=max_items)
+                if reg:
+                    system_instruction = system_instruction + "\n\n" + "MACRO_REGISTRY (from system macros sheet; internal)\n" + reg
+        except Exception:
+            pass
 
         try:
             mem_items = getattr(ws.state, "memory_items", None)

--- a/services/assistance/jarvis-backend/test_sheet_contracts.py
+++ b/services/assistance/jarvis-backend/test_sheet_contracts.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib
 import json
+import os
 import sys
 from typing import Any
 from types import ModuleType
@@ -18,6 +19,9 @@ def _import_main_with_genai_stub(monkeypatch: pytest.MonkeyPatch):
     # Some CI/dev environments running these unit tests may not have the full
     # runtime dependencies installed (e.g. fastapi/httpx). We stub the minimal
     # surface required for importing `main.py` and its helpers.
+    backend_dir = os.path.dirname(os.path.abspath(__file__))
+    if backend_dir and backend_dir not in sys.path:
+        sys.path.insert(0, backend_dir)
     if "httpx" not in sys.modules:
         httpx_stub = ModuleType("httpx")
 
@@ -248,6 +252,34 @@ def _import_main_with_genai_stub(monkeypatch: pytest.MonkeyPatch):
     if "main" in sys.modules:
         return importlib.reload(sys.modules["main"])
     return importlib.import_module("main")
+
+
+def test_system_instruction_from_sys_kv_orders_extras(monkeypatch: pytest.MonkeyPatch):
+    main = _import_main_with_genai_stub(monkeypatch)
+    sys_kv = {
+        "system.instruction": "BASE",
+        "system.instructions.20": "B",
+        "system.instructions.10": "A",
+        "system.instructions.x": "Z",
+        "other": "ignored",
+    }
+    out = main._system_instruction_from_sys_kv(sys_kv)
+    assert out == "BASE\n\nA\n\nB\n\nZ"
+
+
+def test_macro_registry_text_is_compact_and_filters(monkeypatch: pytest.MonkeyPatch) -> None:
+    main = _import_main_with_genai_stub(monkeypatch)
+    macros = {
+        "macro_a": {"name": "macro_a", "description": "A"},
+        "macro_b": {"name": "macro_b", "description": ""},
+        "system_not_macro": {"name": "system_not_macro", "description": "no"},
+    }
+    txt = main._macro_registry_text(macros=macros, max_items=10)
+    assert "macro_a" in txt
+    assert "macro_b" in txt
+    assert "system_not_macro" not in txt
+    # Ensure compact (bulleted) format.
+    assert "- macro_a: A" in txt
 
 
 def test_memo_header_canonical_order_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Moves NL routing guidance into system-sheet-driven instructions and injects a compact macro registry into Gemini Live system prompt.

Changes:
- Adds `_macro_registry_text(...)` and injects `MACRO_REGISTRY` built from macro sheet cache into Live `system_instruction` (gated by `system.macros.registry.*` sys_kv keys).
- Adds contract tests:
  - `system.instructions.*` ordering/assembly (`_system_instruction_from_sys_kv`)
  - macro registry text formatting + macro_* filtering
- Fixes test import helper to import `main.py` reliably under pytest rootdir variations.

Closes #133
Relates-to #129
