### PR TITLE
Docs: macros-only + macro self-test loop

### DIFF
--- a/services/assistance/docs/SYSTEM.md
+++ b/services/assistance/docs/SYSTEM.md
@@ -61,6 +61,52 @@ If Memory/Knowledge is needed, ask the user to run:
 Then continue using the loaded context.
 ```
 
+### `system.instructions.*` (ordered instruction blocks)
+
+In addition to the single `system.instruction` string, Jarvis supports ordered instruction blocks using keys:
+
+- `system.instructions.<priority_int>`
+
+Behavior:
+
+- All enabled `system.instructions.*` keys are collected.
+- `<priority_int>` is parsed as an integer; lower numbers come first.
+- If parsing fails, the block is treated as very low priority (comes last).
+- Final system instruction text is built as:
+  - `system.instruction` (if present)
+  - then the ordered `system.instructions.*` blocks
+
+This is used to make NL routing and policies sheet-driven.
+
+### Macros-only mode (tool surface restriction)
+
+Key:
+
+- `system.macros.only=true`
+
+When enabled, the backend filters tool declarations so Gemini can only see tools prefixed with `system_*` and `macro_*`.
+
+### Macro registry injection (NL routing helper)
+
+Keys:
+
+- `system.macros.registry.enabled` (default true)
+- `system.macros.registry.max_items` (default 30)
+
+When enabled, Jarvis injects a compact macro registry summary into the Gemini system prompt so the model can route NL requests to the appropriate `macro_*` tool.
+
+### Macro fixtures + evaluator (self-test loop)
+
+Keys:
+
+- `system.macros.fixtures.sheet_name` (default `macro_fixtures`)
+- `system.macros.evaluator.enabled` (default false)
+
+Notes:
+
+- `system_macro_test_run` reads fixtures from the fixtures sheet.
+- `system_macro_test_evaluate` is disabled unless explicitly enabled and can optionally queue a pending macro upsert bundle.
+
 ### Portainer integration (module/container status report)
 
 Jarvis supports a deterministic WS action:

--- a/services/assistance/docs/TOOLS.md
+++ b/services/assistance/docs/TOOLS.md
@@ -92,12 +92,66 @@ flowchart TB
     BE --> MEML[memory_list]
     BE --> MADD[memo_add]
     BE --> PL[pending_list]
+    BE --> PG[pending_get]
+    BE --> PP[pending_preview]
     BE --> PC[pending_confirm]
     BE --> PX[pending_cancel]
   end
   BE -->|FunctionResponse| GL
   BE -->|MCP JSON-RPC (Sheets/Calendar/Tasks/etc.)| MCP[MCP servers]
 ```
+
+## Macros-only mode (tool surface restriction)
+
+Jarvis can run in a **macros-only** mode controlled by system sheet KV:
+
+- `system.macros.only=true`
+
+In macros-only mode:
+
+- Only tools prefixed with `system_*` and `macro_*` are declared to Gemini.
+- Macro steps are restricted to `system_*` tools (server-enforced).
+
+This is a hard safety boundary (least privilege): it prevents Gemini from directly declaring or calling broad MCP tools.
+
+## Macro tools (sheet-backed)
+
+Macros are defined in the system macros sheet and surfaced to Gemini as tools named `macro_*`.
+
+Key concepts:
+
+- `macro_*`: a tool that runs a stored sequence of steps.
+- `system_run_macro`: canonical server-side macro runner (invokes the same execution path as `macro_*`).
+- Macro step tools are validated at runtime (no recursion).
+
+## Macro self-test + evaluator loop
+
+Jarvis includes a deterministic test harness for macros:
+
+### Tool: `system_macro_test_run`
+
+Purpose: run a macro against fixtures from the macro fixtures sheet and return a structured report.
+
+- Fixtures sheet: `macro_fixtures` (default)
+- Override via sys_kv: `system.macros.fixtures.sheet_name`
+
+Signature:
+
+- `system_macro_test_run({ name: "macro_*", limit? })`
+
+### Tool: `system_macro_test_evaluate`
+
+Purpose: use an LLM to evaluate a test report and propose a minimal macro update.
+
+Safety:
+
+- Disabled by default.
+- Enable via sys_kv: `system.macros.evaluator.enabled=true`
+- If `queue=true`, the evaluator will create a pending upsert+reload bundle which still requires `pending_confirm`.
+
+Signature:
+
+- `system_macro_test_evaluate({ name: "macro_*", report: <system_macro_test_run output>, queue?, reload_mode? })`
 
 ### Tool: `memo_add`
 
@@ -154,6 +208,8 @@ Purpose: fetch “last created/modified” object for the current voice session.
 Purpose: manage queued “pending” actions (confirmation-based writes).
 
 - `pending_list({})`
+- `pending_get({ confirmation_id })`
+- `pending_preview({ confirmation_id })`
 - `pending_confirm({ confirmation_id })`
 - `pending_cancel({ confirmation_id })`
 


### PR DESCRIPTION
Docs refresh for the macro-only + sheet-driven routing era.

- Document macros-only mode (`system.macros.only`) and its safety boundary.
- Document sys_kv-driven ordered system instructions (`system.instructions.*`).
- Document macro registry injection keys.
- Document macro self-test loop (`system_macro_test_run` / `system_macro_test_evaluate`) including fixtures + evaluator enable flags.
- Document pending tool surface (`pending_get` / `pending_preview`).
