### PR TITLE
Seed baseline macros into sheet (pending-gated)

### DIFF
--- a/services/assistance/jarvis-backend/jarvis/tools_router.py
+++ b/services/assistance/jarvis-backend/jarvis/tools_router.py
@@ -1312,6 +1312,20 @@ async def handle_mcp_tool_call(session_id: Optional[str], tool_name: str, args: 
             ]
             preview["summary"] = f"publish macro '{macro_name}' + system_reload (mode={mode})"
             preview["details"] = {"macro": {"name": macro_name}, "reload_mode": mode}
+        elif action == "bundle_seed_macros" and isinstance(payload, dict):
+            macros = payload.get("macros") if isinstance(payload.get("macros"), list) else []
+            mode = str(payload.get("reload_mode") or "full").strip().lower() or "full"
+            names: list[str] = []
+            for it in macros:
+                if isinstance(it, dict):
+                    nm = str(it.get("name") or "").strip()
+                    if nm:
+                        names.append(nm)
+            preview["risk"] = "high"
+            preview["writes_count"] = len(names)
+            preview["targets"] = [{"kind": "google_sheet", "action": "macro_upsert", "name": nm} for nm in names[:50]]
+            preview["summary"] = f"seed_macros count={len(names)} + reload (mode={mode})"
+            preview["details"] = {"count": len(names), "names": names[:200], "reload_mode": mode}
         elif action == "google_account_relink" and isinstance(payload, dict):
             auth_url = str(payload.get("auth_url") or "").strip()
             redirect_uri = str(payload.get("redirect_uri") or "").strip()
@@ -1586,6 +1600,163 @@ async def handle_mcp_tool_call(session_id: Optional[str], tool_name: str, args: 
                 "macro_write_result": mcp_text_json(macro_write_result),
                 "reload_mode": reload_mode,
                 "reload_result": reload_result,
+            }
+
+        if action == "bundle_seed_macros":
+            ws = session_ws.get(str(session_id)) if isinstance(session_ws, dict) else None
+            if ws is None:
+                raise HTTPException(status_code=400, detail="missing_session_ws")
+            if not isinstance(payload, dict):
+                raise HTTPException(status_code=400, detail="invalid_pending_payload")
+            macros_in = payload.get("macros")
+            reload_mode = str(payload.get("reload_mode") or "full").strip().lower() or "full"
+            if not isinstance(macros_in, list):
+                raise HTTPException(status_code=400, detail="invalid_pending_payload")
+
+            # Upsert each macro row, then reload once.
+            system_spreadsheet_id = deps["system_spreadsheet_id"]
+            system_macros_sheet_name = deps["system_macros_sheet_name"]
+            pick_sheets_tool_name = deps["pick_sheets_tool_name"]
+            mcp_tools_call = deps["mcp_tools_call"]
+            mcp_text_json = deps["mcp_text_json"]
+            sys_kv0 = getattr(ws.state, "sys_kv", None)
+            sys_kv_dict0 = sys_kv0 if isinstance(sys_kv0, dict) else None
+
+            spreadsheet_id = str(system_spreadsheet_id() or "").strip()
+            if not spreadsheet_id:
+                raise HTTPException(status_code=400, detail="missing_system_spreadsheet_id")
+            sheet_name = str(system_macros_sheet_name(sys_kv=sys_kv_dict0) or "").strip() or "macros"
+
+            tool_get = pick_sheets_tool_name("google_sheets_values_get", "google_sheets_values_get")
+            res = await mcp_tools_call(tool_get, {"spreadsheet_id": spreadsheet_id, "range": f"{sheet_name}!A:Z"})
+            parsed = mcp_text_json(res)
+            values = parsed.get("values") if isinstance(parsed, dict) else None
+            data = parsed.get("data") if isinstance(parsed, dict) else None
+            if not isinstance(values, list) and isinstance(data, dict):
+                values = data.get("values")
+            if not isinstance(values, list) or not values:
+                raise HTTPException(status_code=400, detail="system_macros_sheet_empty")
+
+            header = [str(c or "").strip().lower() for c in (values[0] if isinstance(values[0], list) else [])]
+            idx: dict[str, int] = {}
+            for i, col in enumerate(header):
+                if col and col not in idx:
+                    idx[col] = int(i)
+
+            required_cols = ["name", "enabled", "description", "parameters_json", "steps_json"]
+            missing = [c for c in required_cols if c not in idx]
+            if missing:
+                raise HTTPException(status_code=400, detail={"system_macros_sheet_missing_columns": missing})
+
+            def _col_letter(col_idx0: int) -> str:
+                n = int(col_idx0) + 1
+                if n <= 0:
+                    return "A"
+                out = ""
+                while n > 0:
+                    n, r = divmod(n - 1, 26)
+                    out = chr(ord("A") + r) + out
+                return out or "A"
+
+            def _cell(row: list[Any], col: str) -> Any:
+                j = idx.get(str(col or "").strip().lower())
+                if j is None or j < 0 or j >= len(row):
+                    return ""
+                return row[j]
+
+            max_col = max(idx[c] for c in required_cols)
+            tool_append = pick_sheets_tool_name("google_sheets_values_append", "google_sheets_values_append")
+            tool_update = pick_sheets_tool_name("google_sheets_values_update", "google_sheets_values_update")
+
+            writes: list[dict[str, Any]] = []
+            for macro_args in macros_in:
+                if not isinstance(macro_args, dict):
+                    continue
+                name = str(macro_args.get("name") or "").strip()
+                if not name:
+                    continue
+                enabled = macro_args.get("enabled")
+                if enabled is None:
+                    enabled = True
+                enabled_cell = "TRUE" if bool(enabled) else "FALSE"
+                description = str(macro_args.get("description") or "").strip()
+                parameters_json = str(macro_args.get("parameters_json") or "").strip()
+                steps_json = str(macro_args.get("steps_json") or "").strip()
+                if not steps_json:
+                    continue
+
+                found_row_num: int | None = None
+                for i, r in enumerate(values[1:], start=2):
+                    if not isinstance(r, list):
+                        continue
+                    nm = str(_cell(r, "name") or "").strip()
+                    if nm == name:
+                        found_row_num = int(i)
+                        break
+
+                row_out: list[Any] = [""] * (max_col + 1)
+                row_out[idx["name"]] = name
+                row_out[idx["enabled"]] = enabled_cell
+                row_out[idx["description"]] = description
+                row_out[idx["parameters_json"]] = parameters_json
+                row_out[idx["steps_json"]] = steps_json
+
+                if found_row_num is None:
+                    res_w = await mcp_tools_call(
+                        tool_append,
+                        {
+                            "spreadsheet_id": spreadsheet_id,
+                            "range": f"{sheet_name}!A:Z",
+                            "values": [row_out],
+                            "value_input_option": "RAW",
+                        },
+                    )
+                    writes.append({"name": name, "op": "append", "result": mcp_text_json(res_w)})
+                else:
+                    start_col = _col_letter(0)
+                    end_col = _col_letter(max_col)
+                    res_w = await mcp_tools_call(
+                        tool_update,
+                        {
+                            "spreadsheet_id": spreadsheet_id,
+                            "range": f"{sheet_name}!{start_col}{found_row_num}:{end_col}{found_row_num}",
+                            "values": [row_out],
+                            "value_input_option": "RAW",
+                        },
+                    )
+                    writes.append({"name": name, "op": "update", "row": found_row_num, "result": mcp_text_json(res_w)})
+
+            # Reload system after seeding.
+            try:
+                await ws.send_json({"type": "text", "text": "reloading system"})
+            except Exception:
+                pass
+            reload_result: Any
+            if system_reload_impl is not None:
+                reload_result = await system_reload_impl(ws)
+            else:
+                sys_kv = await load_ws_system_kv(ws)
+                macros = await macro_tools_force_reload_from_sheet(sys_kv=sys_kv if isinstance(sys_kv, dict) else None)
+                keys = sorted([str(k or "").strip() for k in (sys_kv or {}).keys()]) if isinstance(sys_kv, dict) else []
+                reload_result = {"ok": True, "sys_kv": sys_kv if isinstance(sys_kv, dict) else None, "sys_kv_keys": keys, "macros_count": len(macros or {})}
+
+            try:
+                lang = str(getattr(getattr(ws, "state", None), "user_lang", "") or "").strip() or "en"
+                done_txt = "system reloaded" if lang != "th" else "รีโหลดระบบสำเร็จ"
+                await ws.send_json({"type": "text", "text": done_txt})
+            except Exception:
+                pass
+
+            return {
+                "ok": True,
+                "bundle": True,
+                "seeded": True,
+                "count": len(writes),
+                "writes": writes,
+                "reload_mode": reload_mode,
+                "reload_result": reload_result,
+                "sheet": sheet_name,
+                "spreadsheet_id": spreadsheet_id,
             }
 
         if action == "google_account_relink":

--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -13511,6 +13511,19 @@ def _mcp_tool_declarations() -> list[dict[str, Any]]:
 
     decls.append(
         {
+            "name": "system_macro_seed_baseline_queue",
+            "description": "Queue a confirmation-gated write to upsert baseline macros into the system macros sheet (useful for seeding an empty sheet).",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "reload_mode": {"type": "string", "description": "Reload mode to run after seeding (default full)."},
+                },
+            },
+        }
+    )
+
+    decls.append(
+        {
             "name": "system_run_macro",
             "description": "Run a configured macro tool by name (server-side canonical runner).",
             "parameters": {
@@ -14291,6 +14304,62 @@ async def _handle_mcp_tool_call(session_id: Optional[str], tool_name: str, args:
             out["confirmation_id"] = confirmation_id
             out["reload_mode"] = mode
         return out
+
+    if n == "system_macro_seed_baseline_queue":
+        if not session_id:
+            raise HTTPException(status_code=400, detail="missing_session_id")
+        mode = str((args or {}).get("reload_mode") or "full").strip().lower() or "full"
+        if mode not in {"full", "all", "memory", "knowledge", "sys", "gems"}:
+            raise HTTPException(status_code=400, detail="invalid_reload_mode")
+
+        macros = _macro_tools_cached_snapshot()
+        if not macros:
+            macros = {
+                "macro_time_now": {
+                    "name": "macro_time_now",
+                    "description": "Sample macro: return current server time (calls time_now).",
+                    "parameters": {"type": "object", "properties": {}},
+                    "steps": [{"tool": "time_now", "args": {}}],
+                }
+            }
+
+        seed: list[dict[str, Any]] = []
+        for k, v in (macros or {}).items():
+            name = str(k or "").strip()
+            if not name.startswith("macro_"):
+                continue
+            if not isinstance(v, dict):
+                continue
+            desc = str(v.get("description") or "").strip()
+            params = v.get("parameters") if isinstance(v.get("parameters"), dict) else {"type": "object", "properties": {}}
+            steps = v.get("steps") if isinstance(v.get("steps"), list) else []
+            try:
+                parameters_json = json.dumps(params, ensure_ascii=False)
+            except Exception:
+                parameters_json = "{}"
+            try:
+                steps_json = json.dumps(steps, ensure_ascii=False)
+            except Exception:
+                steps_json = "[]"
+            if not str(steps_json or "").strip():
+                continue
+            seed.append(
+                {
+                    "name": name,
+                    "enabled": True,
+                    "description": desc,
+                    "parameters_json": parameters_json,
+                    "steps_json": steps_json,
+                }
+            )
+        seed.sort(key=lambda m: str(m.get("name") or ""))
+
+        confirmation_id = _create_pending_write(
+            str(session_id),
+            "bundle_seed_macros",
+            {"macros": seed, "reload_mode": mode},
+        )
+        return {"ok": True, "queued": True, "confirmation_id": confirmation_id, "macros": len(seed), "reload_mode": mode}
 
     if n == "system_run_macro":
         macro_name = str((args or {}).get("name") or "").strip()

--- a/services/assistance/jarvis-backend/test_sheet_contracts.py
+++ b/services/assistance/jarvis-backend/test_sheet_contracts.py
@@ -958,6 +958,33 @@ def test_system_macro_test_run_uses_fixtures_sheet(monkeypatch: pytest.MonkeyPat
     assert report.get("passed") == 1
 
 
+def test_system_macro_seed_baseline_queue_creates_pending_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
+    main = _import_main_with_genai_stub(monkeypatch)
+
+    pending: dict[str, Any] = {}
+
+    def fake_create_pending_write(session_id: str, action: str, payload: Any) -> str:
+        assert session_id == "s1"
+        assert action == "bundle_seed_macros"
+        pending["payload"] = payload
+        return "pw_seed"
+
+    monkeypatch.setattr(main, "_create_pending_write", fake_create_pending_write)
+    monkeypatch.setattr(main, "_MACRO_TOOL_CACHE", {"ts": 0.0, "macros": {}})
+
+    out = asyncio.run(main._handle_mcp_tool_call("s1", "system_macro_seed_baseline_queue", {"reload_mode": "full"}))
+    assert out.get("ok") is True
+    assert out.get("queued") is True
+    assert out.get("confirmation_id") == "pw_seed"
+
+    payload = pending.get("payload")
+    assert isinstance(payload, dict)
+    assert payload.get("reload_mode") == "full"
+    macros = payload.get("macros")
+    assert isinstance(macros, list)
+    assert any(isinstance(m, dict) and str(m.get("name") or "") == "macro_time_now" for m in macros)
+
+
 def test_system_macro_test_evaluate_requires_flag_and_parses_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     main = _import_main_with_genai_stub(monkeypatch)
 


### PR DESCRIPTION
Adds a confirmation-gated seeding tool so the macro sheet can be populated intentionally.

- New tool: `system_macro_seed_baseline_queue`
  - Queues a pending action `bundle_seed_macros` containing baseline `macro_*` definitions.
  - Does not write until `pending_confirm`.
- `pending_preview` now shows a summary for `bundle_seed_macros`.
- `pending_confirm` executes the bundle: upserts each macro row then reloads system once.

Tests:
- Adds a contract test asserting the seed tool queues the bundle and includes at least `macro_time_now` when cache is empty.
