### PR TITLE
Allow /tool system_macro_seed_baseline_queue

### DIFF
--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -8320,6 +8320,7 @@ async def _handle_local_tools_message(ws: WebSocket, msg: dict[str, Any], trace_
             "pending_cancel",
             "system_reload_queue",
             "system_macro_upsert_bundle_queue",
+            "system_macro_seed_baseline_queue",
             "google_account_relink_queue",
         }
         if name not in allowed:


### PR DESCRIPTION
Fixes WS local tool allowlist to permit running the new macro seeding tool from the web UI `/tool` command.

- Allow `system_macro_seed_baseline_queue` in `_handle_local_tools_message` allowlist.
