### PR TITLE
docs: add SSOT pointers (ui/debug) (Issue #96)

### DIFF
--- a/services/assistance/docs/UI.md
+++ b/services/assistance/docs/UI.md
@@ -2,6 +2,12 @@
 
 This file documents the high-level UI structure for `jarvis-frontend`.
 
+Operator SSOT:
+- `services/assistance/docs/ACTION.md`
+
+API SSOT:
+- Prefer the live backend OpenAPI: `GET /openapi.json`
+
 ## Structure (diagram)
 
 ```mermaid

--- a/services/assistance/jarvis-backend/DEBUG.md
+++ b/services/assistance/jarvis-backend/DEBUG.md
@@ -2,6 +2,12 @@
 
 This file is intentionally short. The primary runbook lives at `services/assistance/DEBUG.md`.
 
+Operator SSOT:
+- `services/assistance/docs/ACTION.md`
+
+API SSOT:
+- Prefer the live backend OpenAPI: `GET /openapi.json`
+
 ## Quick checks
 
 - `GET /health`

--- a/services/assistance/jarvis-frontend/DEBUG.md
+++ b/services/assistance/jarvis-frontend/DEBUG.md
@@ -2,6 +2,12 @@
 
 This file is intentionally short. The primary runbook lives at `services/assistance/DEBUG.md`.
 
+Operator SSOT:
+- `services/assistance/docs/ACTION.md`
+
+API SSOT:
+- Prefer the live backend OpenAPI: `GET /openapi.json`
+
 ## Quick checks
 
 - Confirm the SPA loads.


### PR DESCRIPTION
Issue: #96\n\nPointer-only doc hygiene to reduce drift:\n- services/assistance/docs/UI.md: add pointers to operator SSOT (ACTION.md) and API SSOT (GET /openapi.json)\n- services/assistance/jarvis-backend/DEBUG.md: add the same SSOT pointers\n- services/assistance/jarvis-frontend/DEBUG.md: add the same SSOT pointers\n\nNo behavior changes.