### PR TITLE
docs(idc1-stack): add SSOT pointers (Issue #96)

### DIFF
--- a/services/assistance/docs/CLEANUP.md
+++ b/services/assistance/docs/CLEANUP.md
@@ -1,5 +1,9 @@
 # Cleanup: Docker disk full (Portainer pull fails)
 
+Operator SSOT:
+
+- `services/assistance/docs/ACTION.md`
+
 ## Symptom
 
 Portainer stack deploy/pull fails with errors like:

--- a/services/assistance/docs/CONFIG.md
+++ b/services/assistance/docs/CONFIG.md
@@ -8,6 +8,14 @@ Rules:
 - Prefer documenting **actual bind ports/URLs** that operators use.
 - Compose defaults do not override values configured in **Portainer stack env**.
 
+Operator SSOT:
+
+- `services/assistance/docs/ACTION.md`
+
+API SSOT:
+
+- Prefer the live backend OpenAPI: `GET /openapi.json`
+
 ## Host endpoints (effective)
 
 - Jarvis UI:

--- a/services/assistance/docs/IMAGEN.md
+++ b/services/assistance/docs/IMAGEN.md
@@ -1,5 +1,13 @@
 # Imagen Projects (Ground Truth Spec)
 
+Operator SSOT:
+
+- `services/assistance/docs/ACTION.md`
+
+API SSOT:
+
+- Prefer the live backend OpenAPI: `GET /openapi.json`
+
 ## Objective
 Build an **Imagen Project workflow** in Jarvis using the **Gemini Developer API key** (**server-side only**).
 

--- a/services/assistance/docs/MEMO.md
+++ b/services/assistance/docs/MEMO.md
@@ -1,5 +1,13 @@
 # Memo system
 
+Operator SSOT:
+
+- `services/assistance/docs/ACTION.md`
+
+API SSOT:
+
+- Prefer the live backend OpenAPI: `GET /openapi.json`
+
 ## Overview
 The memo system provides a lightweight, append-only log into a Google Sheet tab (default: `memo`).
 

--- a/services/assistance/docs/MEMO_SHEET_HANDOFF.md
+++ b/services/assistance/docs/MEMO_SHEET_HANDOFF.md
@@ -1,5 +1,13 @@
 # Memo / Memory Sheet Handoff (Jarvis)
 
+Operator SSOT:
+
+- `services/assistance/docs/ACTION.md`
+
+API SSOT:
+
+- Prefer the live backend OpenAPI: `GET /openapi.json`
+
 This doc is meant to be a quick handoff for another chat/session to safely work on Jarvis “memo/memory sheet” behavior without having to re-discover the conventions.
 
 ## What “memo sheet” means in this repo

--- a/services/assistance/docs/TEST.md
+++ b/services/assistance/docs/TEST.md
@@ -1,5 +1,13 @@
 # Test info
 
+Operator SSOT:
+
+- `services/assistance/docs/ACTION.md`
+
+API SSOT:
+
+- Prefer the live backend OpenAPI: `GET /openapi.json`
+
 ## Context
 
 This file is a scratchpad for validating the GitHub Actions watcher integration in Jarvis.

--- a/services/assistance/docs/WEAVIATE.md
+++ b/services/assistance/docs/WEAVIATE.md
@@ -1,5 +1,13 @@
 # Weaviate Memory Store (Ground Truth Spec)
 
+Operator SSOT:
+
+- `services/assistance/docs/ACTION.md`
+
+API SSOT:
+
+- Prefer the live backend OpenAPI: `GET /openapi.json`
+
  See also:
  - `WINDSURF_PLAYBOOK.md` (repo working conventions, diagnostics, workflows)
 

--- a/stacks/idc1-assistance/CONFIG.md
+++ b/stacks/idc1-assistance/CONFIG.md
@@ -8,6 +8,14 @@ Rules:
 - Prefer documenting **effective bind ports/URLs** that operators use.
 - Compose defaults do not override values configured in **Portainer stack env**.
 
+Operator SSOT:
+
+- `services/assistance/docs/ACTION.md`
+
+API SSOT:
+
+- Prefer the live backend OpenAPI: `GET /openapi.json`
+
 ## Host endpoints (effective)
 
 Loopback binds (host):
@@ -102,6 +110,9 @@ Frontend:
 - If generating `mcp.json` via heredoc in compose, avoid `${VAR}` in the JSON content (compose may expand it at deploy-time). Prefer `$${VAR}`.
 
 ## Verification checklist (post-redeploy)
+
+- Operator SSOT:
+  - See `services/assistance/docs/ACTION.md` for the current deployed verification checklist and exact commands.
 
 - Backend health:
   - `curl -fsS http://127.0.0.1:18018/health`

--- a/stacks/idc1-assistance/DEBUG.md
+++ b/stacks/idc1-assistance/DEBUG.md
@@ -7,6 +7,14 @@ Rules:
 - These files are for local/operator testing.
 - Do not commit secrets to git. Use `./.env.local` (already gitignored).
 
+Operator SSOT:
+
+- `services/assistance/docs/ACTION.md`
+
+API SSOT:
+
+- Prefer the live backend OpenAPI: `GET /openapi.json`
+
 ## Debug MCP bundle
 
 Start MCP bundle on port `4051`:


### PR DESCRIPTION
Issue: #96

Pointer-only doc hygiene to reduce drift:

- stacks/idc1-assistance/CONFIG.md: add pointers to operator SSOT (services/assistance/docs/ACTION.md) + API SSOT (GET /openapi.json); make post-redeploy verification explicitly defer to ACTION.md
- stacks/idc1-assistance/DEBUG.md: add the same SSOT pointers
- services/assistance/docs/CLEANUP.md: add operator SSOT pointer (ACTION.md)
- services/assistance/docs/TEST.md: add operator + API SSOT pointers
- services/assistance/docs/IMAGEN.md: add operator + API SSOT pointers
- services/assistance/docs/WEAVIATE.md: add operator + API SSOT pointers

No behavior changes.