### PR TITLE
fix(current-news): use web-fetcher for RSS/Atom (avoid robots gating)

### DIFF
--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -11802,11 +11802,29 @@ async def _fetch_news_items_from_source(
     debug: bool = False,
     debug_out: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
-    text = await _mcp_web_fetch_text(url, max_length=350000, raw=True)
+    fetch_meta: dict[str, Any] = {}
+    text = ""
+    try:
+        res = await _web_fetcher_post("/fetch", {"url": url})
+        if isinstance(res, dict):
+            text = str(res.get("text") or "")
+            fetch_meta = {
+                "status_code": res.get("status_code"),
+                "content_type": res.get("content_type"),
+                "final_url": res.get("final_url"),
+            }
+        else:
+            text = ""
+    except Exception as e:
+        text = str(e)
+
     if debug and isinstance(debug_out, list):
         try:
             preview = str(text or "")[:240]
-            debug_out.append({"url": url, "len": len(str(text or "")), "preview": preview})
+            row: dict[str, Any] = {"url": url, "len": len(str(text or "")), "preview": preview}
+            if isinstance(fetch_meta, dict) and fetch_meta:
+                row.update(fetch_meta)
+            debug_out.append(row)
         except Exception:
             pass
 

--- a/services/assistance/web-fetcher/main.py
+++ b/services/assistance/web-fetcher/main.py
@@ -22,7 +22,10 @@ CA_BUNDLE = str(os.getenv("WEB_FETCH_CA_BUNDLE") or "/etc/ssl/certs/ca-certifica
 
 ALLOWED_CONTENT_TYPES = tuple(
     ct.strip().lower()
-    for ct in (os.getenv("WEB_FETCH_ALLOWED_CONTENT_TYPES") or "text/html,text/plain,application/json").split(",")
+    for ct in (
+        os.getenv("WEB_FETCH_ALLOWED_CONTENT_TYPES")
+        or "text/html,text/plain,application/json,application/rss+xml,application/atom+xml,application/xml,text/xml"
+    ).split(",")
     if ct.strip()
 )
 


### PR DESCRIPTION
Backend+web-fetcher fix.

Problem: current_news_refresh sources_count>0 but items_loaded=0 because MCP web_fetch returns 'Failed to fetch robots.txt ...' for some hosts (cnn).

Fix:
- current-news feed fetching now uses internal web-fetcher (/fetch) instead of MCP web_fetch.
- web-fetcher default allowed content-types now include RSS/Atom/XML.
- Debug output still includes preview/len + now also includes status_code/content_type/final_url when available.