### PR TITLE
fix(web-fetcher): surface upstream fetch errors

### DIFF
--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -11815,8 +11815,15 @@ async def _fetch_news_items_from_source(
             }
         else:
             text = ""
+    except HTTPException as e:
+        text = ""
+        try:
+            fetch_meta = {"status_code": e.status_code, "detail": e.detail}
+        except Exception:
+            fetch_meta = {"status_code": getattr(e, "status_code", None)}
     except Exception as e:
-        text = str(e)
+        text = ""
+        fetch_meta = {"error": e.__class__.__name__, "message": str(e)}
 
     if debug and isinstance(debug_out, list):
         try:

--- a/services/assistance/web-fetcher/main.py
+++ b/services/assistance/web-fetcher/main.py
@@ -129,7 +129,18 @@ def _html_to_text(html: str) -> tuple[str, Optional[str]]:
 async def _fetch_once(client: httpx.AsyncClient, url: str) -> dict[str, Any]:
     _enforce_ssrf(url)
 
-    res = await client.get(url)
+    try:
+        res = await client.get(url)
+    except httpx.RequestError as e:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "upstream_request_failed",
+                "url": url,
+                "exception": e.__class__.__name__,
+                "message": str(e),
+            },
+        )
 
     # Handle redirects manually so we can SSRF-check each hop.
     if res.status_code in (301, 302, 303, 307, 308):


### PR DESCRIPTION
Backend+web-fetcher fix.

- web-fetcher: convert httpx.RequestError into HTTP 502 with structured detail (exception/message/url) instead of returning generic 500.
- jarvis-backend current_news: when web-fetcher call fails, capture status_code + detail into context._debug.fetch (and avoid parsing error strings as XML).

This should make it clear why rss.cnn.com fails in the deployed network/TLS environment.