### PR TITLE
fix(web-fetcher): accept rss/xml content-types

### DIFF
--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -11815,8 +11815,15 @@ async def _fetch_news_items_from_source(
             }
         else:
             text = ""
+    except HTTPException as e:
+        text = ""
+        try:
+            fetch_meta = {"status_code": e.status_code, "detail": e.detail}
+        except Exception:
+            fetch_meta = {"status_code": getattr(e, "status_code", None)}
     except Exception as e:
-        text = str(e)
+        text = ""
+        fetch_meta = {"error": e.__class__.__name__, "message": str(e)}
 
     if debug and isinstance(debug_out, list):
         try:

--- a/services/assistance/web-fetcher/main.py
+++ b/services/assistance/web-fetcher/main.py
@@ -107,7 +107,12 @@ def _content_type_allowed(content_type_header: str) -> bool:
     content_type = (content_type_header or "").split(";")[0].strip().lower()
     if not content_type:
         return False
-    return any(content_type == allowed for allowed in ALLOWED_CONTENT_TYPES)
+    if any(content_type == allowed for allowed in ALLOWED_CONTENT_TYPES):
+        return True
+    # Some feeds return non-standard but still-safe XML-ish content-types.
+    if "xml" in content_type or "rss" in content_type or "atom" in content_type:
+        return True
+    return False
 
 
 def _html_to_text(html: str) -> tuple[str, Optional[str]]:
@@ -151,7 +156,13 @@ async def _fetch_once(client: httpx.AsyncClient, url: str) -> dict[str, Any]:
 
     content_type = res.headers.get("content-type") or ""
     if not _content_type_allowed(content_type):
-        raise HTTPException(status_code=415, detail="unsupported_content_type")
+        raise HTTPException(
+            status_code=415,
+            detail={
+                "error": "unsupported_content_type",
+                "content_type": (content_type or "").strip(),
+            },
+        )
 
     # Streaming byte limit enforcement
     total = 0

--- a/services/assistance/web-fetcher/main.py
+++ b/services/assistance/web-fetcher/main.py
@@ -129,7 +129,18 @@ def _html_to_text(html: str) -> tuple[str, Optional[str]]:
 async def _fetch_once(client: httpx.AsyncClient, url: str) -> dict[str, Any]:
     _enforce_ssrf(url)
 
-    res = await client.get(url)
+    try:
+        res = await client.get(url)
+    except httpx.RequestError as e:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "upstream_request_failed",
+                "url": url,
+                "exception": e.__class__.__name__,
+                "message": str(e),
+            },
+        )
 
     # Handle redirects manually so we can SSRF-check each hop.
     if res.status_code in (301, 302, 303, 307, 308):


### PR DESCRIPTION
web-fetcher fix.

- Accept common RSS/Atom/XML-ish content-types (fallback check for 'xml'/'rss'/'atom' substrings)
- Return 415 with structured detail including observed content_type

This unblocks RSS fetching for current_news_refresh sources.