### PR TITLE
feat(current-news): persist fetched items to news_items tab

### DIFF
--- a/services/assistance/jarvis-backend/jarvis/tools_router.py
+++ b/services/assistance/jarvis-backend/jarvis/tools_router.py
@@ -1160,7 +1160,7 @@ async def handle_mcp_tool_call(session_id: Optional[str], tool_name: str, args: 
                 ctx = None
 
             if tool_name == "current_news_refresh":
-                ctx = await refresh_current_news_cache(sys_kv=sys_kv if isinstance(sys_kv, dict) else None)
+                ctx = await refresh_current_news_cache(sys_kv=sys_kv if isinstance(sys_kv, dict) else None, force_fetch=True)
                 try:
                     set_news_cache("current-news", ctx)
                 except Exception:
@@ -1168,7 +1168,7 @@ async def handle_mcp_tool_call(session_id: Optional[str], tool_name: str, args: 
                 return {"ok": True, "refreshed": True, "context": ctx, "brief": render_current_news_brief(ctx) if isinstance(ctx, dict) else ""}
 
             if ctx is None:
-                ctx = await refresh_current_news_cache(sys_kv=sys_kv if isinstance(sys_kv, dict) else None)
+                ctx = await refresh_current_news_cache(sys_kv=sys_kv if isinstance(sys_kv, dict) else None, force_fetch=False)
                 try:
                     set_news_cache("current-news", ctx)
                 except Exception:

--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -3926,6 +3926,30 @@ def _current_news_topics_sheet_cfg_from_sys_kv(sys_kv: dict[str, Any] | None) ->
     return (spreadsheet_id, sheet_name)
 
 
+def _current_news_items_sheet_cfg_from_sys_kv(sys_kv: dict[str, Any] | None) -> tuple[str, str]:
+    spreadsheet_id = ""
+    sheet_name = ""
+    if isinstance(sys_kv, dict):
+        spreadsheet_id = str(
+            sys_kv.get("current_news.items.spreadsheet_id")
+            or sys_kv.get("current_news.items.spreadsheet_name")
+            or sys_kv.get("current_news.spreadsheet_id")
+            or sys_kv.get("current_news_ss")
+            or ""
+        ).strip()
+        sheet_name = str(
+            sys_kv.get("current_news.items.sheet_name")
+            or sys_kv.get("news_items.sheet_name")
+            or sys_kv.get("news_items_sh")
+            or ""
+        ).strip()
+    if not spreadsheet_id:
+        spreadsheet_id = _system_spreadsheet_id()
+    if not sheet_name:
+        sheet_name = "news_items"
+    return (spreadsheet_id, sheet_name)
+
+
 async def _sheet_get_header_row(*, spreadsheet_id: str, sheet_a1: str, max_cols: str = "Z") -> list[Any]:
     return await sheets_utils.sheet_get_header_row(
         spreadsheet_id=spreadsheet_id,
@@ -11872,59 +11896,127 @@ async def _load_current_news_items_from_sheet(*, sys_kv: dict[str, Any] | None) 
     return out
 
 
-async def _refresh_current_news_cache(*, sys_kv: dict[str, Any] | None = None) -> dict[str, Any]:
+async def _load_current_news_items_from_items_tab(*, sys_kv: dict[str, Any] | None) -> list[dict[str, Any]]:
+    spreadsheet_id, sheet_name = _current_news_items_sheet_cfg_from_sys_kv(sys_kv)
+    if not spreadsheet_id:
+        raise RuntimeError("current_news_missing_spreadsheet_id")
+    sheet_a1 = sheets_utils.sheet_name_to_a1(sheet_name, default="news_items")
+
+    table = await _load_sheet_table(spreadsheet_id=spreadsheet_id, sheet_name=sheet_a1, max_rows=800, max_cols="H")
+    if not table:
+        return []
+    header = table[0] if isinstance(table[0], list) else []
+    idx = _idx_from_header(header)
+    if not idx:
+        return []
+
+    out: list[dict[str, Any]] = []
+    for r in table[1:]:
+        if not isinstance(r, list):
+            continue
+        title = _cell_str(r, idx, "title")
+        link = _cell_str(r, idx, "link") or _cell_str(r, idx, "url")
+        desc = _cell_str(r, idx, "description")
+        pub = _cell_str(r, idx, "pubdate") or _cell_str(r, idx, "published")
+        if not title and not link:
+            continue
+        out.append({"title": title, "link": link, "pubDate": pub, "description": desc})
+    return out
+
+
+async def _save_current_news_items_to_items_tab(*, items: list[dict[str, Any]], sys_kv: dict[str, Any] | None) -> None:
+    spreadsheet_id, sheet_name = _current_news_items_sheet_cfg_from_sys_kv(sys_kv)
+    if not spreadsheet_id:
+        return
+    sheet_a1 = sheets_utils.sheet_name_to_a1(sheet_name, default="news_items")
+
+    max_rows = 500
+    if isinstance(sys_kv, dict):
+        try:
+            max_rows = int(sys_kv.get("current_news.items.max_rows") or 500)
+        except Exception:
+            max_rows = 500
+    max_rows = max(10, min(max_rows, 2000))
+
+    rows: list[list[Any]] = [["title", "link", "pubDate", "description"]]
+    for it in (items or [])[:max_rows]:
+        if not isinstance(it, dict):
+            continue
+        rows.append([
+            str(it.get("title") or ""),
+            str(it.get("link") or ""),
+            str(it.get("pubDate") or ""),
+            str(it.get("description") or ""),
+        ])
+
+    tool_update = _pick_sheets_tool_name("google_sheets_values_update", "google_sheets_values_update")
+    rng = f"{sheet_a1}!A1:D{len(rows)}"
+    await _mcp_tools_call(
+        tool_update,
+        {
+            "spreadsheet_id": spreadsheet_id,
+            "range": rng,
+            "values": rows,
+            "value_input_option": "RAW",
+        },
+    )
+
+
+async def _refresh_current_news_cache(
+    *,
+    sys_kv: dict[str, Any] | None = None,
+    force_fetch: bool = True,
+) -> dict[str, Any]:
     sources_rows: list[dict[str, Any]] = []
     topics_cfg: dict[str, dict[str, Any]] = {}
     all_items: list[dict[str, Any]] = []
     fetch_debug: list[dict[str, Any]] = []
 
     try:
-        sources_rows = await _load_news_sources_from_sheet(sys_kv=sys_kv)
-    except Exception:
-        sources_rows = []
-    try:
         topics_cfg = await _load_news_topics_from_sheet(sys_kv=sys_kv)
     except Exception:
         topics_cfg = {}
 
-    if sources_rows:
-        for src in sources_rows:
-            try:
-                url = str(src.get("url") or "").strip()
-                if not url:
-                    continue
-                all_items.extend(
-                    await _fetch_news_items_from_source(
-                        url,
-                        debug=_sys_kv_bool(sys_kv, "current_news.debug.enabled", default=False),
-                        debug_out=fetch_debug,
-                    )
-                )
-            except Exception:
-                continue
-    else:
-        spreadsheet_id, sheet_name = _current_news_sheet_cfg_from_sys_kv(sys_kv)
-        sheet_a1 = sheets_utils.sheet_name_to_a1(sheet_name, default="current_news")
-
-        table: list[list[Any]] = []
-        header: list[Any] = []
-        idx: dict[str, int] = {}
+    if not force_fetch:
         try:
-            table = await _load_sheet_table(spreadsheet_id=spreadsheet_id, sheet_name=sheet_a1, max_rows=500, max_cols="H")
-            header = table[0] if isinstance(table[0], list) else []
-            idx = _idx_from_header(header)
-            for r in table[1:]:
-                if not isinstance(r, list):
-                    continue
-                title = _cell_str(r, idx, "title")
-                link = _cell_str(r, idx, "link") or _cell_str(r, idx, "url")
-                desc = _cell_str(r, idx, "description")
-                pub = _cell_str(r, idx, "pubdate") or _cell_str(r, idx, "published")
-                if not title and not link:
-                    continue
-                all_items.append({"title": title, "link": link, "pubDate": pub, "description": desc})
+            all_items = await _load_current_news_items_from_items_tab(sys_kv=sys_kv)
         except Exception:
-            all_items = await _load_current_news_items_from_sheet(sys_kv=sys_kv)
+            all_items = []
+
+    if not all_items:
+        try:
+            sources_rows = await _load_news_sources_from_sheet(sys_kv=sys_kv)
+        except Exception:
+            sources_rows = []
+
+        if sources_rows:
+            for src in sources_rows:
+                try:
+                    url = str(src.get("url") or "").strip()
+                    if not url:
+                        continue
+                    all_items.extend(
+                        await _fetch_news_items_from_source(
+                            url,
+                            debug=_sys_kv_bool(sys_kv, "current_news.debug.enabled", default=False),
+                            debug_out=fetch_debug,
+                        )
+                    )
+                except Exception:
+                    continue
+            try:
+                await _save_current_news_items_to_items_tab(items=all_items, sys_kv=sys_kv)
+            except Exception:
+                pass
+        else:
+            try:
+                all_items = await _load_current_news_items_from_sheet(sys_kv=sys_kv)
+            except Exception:
+                all_items = []
+            try:
+                await _save_current_news_items_to_items_tab(items=all_items, sys_kv=sys_kv)
+            except Exception:
+                pass
 
     seen: set[str] = set()
     deduped: list[dict[str, Any]] = []
@@ -11991,7 +12083,10 @@ async def _handle_current_news_trigger(ws: WebSocket, text: str) -> bool:
 
     if wants_refresh or ctx is None:
         sys_kv = getattr(ws.state, "sys_kv", None)
-        ctx = await _refresh_current_news_cache(sys_kv=sys_kv if isinstance(sys_kv, dict) else None)
+        ctx = await _refresh_current_news_cache(
+            sys_kv=sys_kv if isinstance(sys_kv, dict) else None,
+            force_fetch=bool(wants_refresh),
+        )
 
     if not isinstance(ctx, dict):
         return False
@@ -12049,13 +12144,13 @@ async def current_news_brief() -> dict[str, Any]:
     if cached and isinstance(cached.get("payload"), dict):
         ctx = cached["payload"]
         return {"ok": True, "cached": True, "brief": _render_current_news_brief(ctx), "context": ctx}
-    ctx2 = await _refresh_current_news_cache()
+    ctx2 = await _refresh_current_news_cache(force_fetch=False)
     return {"ok": True, "cached": False, "brief": _render_current_news_brief(ctx2), "context": ctx2}
 
 
 @app.post("/current-news/refresh")
 async def current_news_refresh() -> dict[str, Any]:
-    ctx = await _refresh_current_news_cache()
+    ctx = await _refresh_current_news_cache(force_fetch=True)
     return {"ok": True, "context": ctx}
 
 

--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -11815,8 +11815,15 @@ async def _fetch_news_items_from_source(
             }
         else:
             text = ""
+    except HTTPException as e:
+        text = ""
+        try:
+            fetch_meta = {"status_code": e.status_code, "detail": e.detail}
+        except Exception:
+            fetch_meta = {"status_code": getattr(e, "status_code", None)}
     except Exception as e:
-        text = str(e)
+        text = ""
+        fetch_meta = {"error": e.__class__.__name__, "message": str(e)}
 
     if debug and isinstance(debug_out, list):
         try:

--- a/services/assistance/web-fetcher/main.py
+++ b/services/assistance/web-fetcher/main.py
@@ -107,7 +107,12 @@ def _content_type_allowed(content_type_header: str) -> bool:
     content_type = (content_type_header or "").split(";")[0].strip().lower()
     if not content_type:
         return False
-    return any(content_type == allowed for allowed in ALLOWED_CONTENT_TYPES)
+    if any(content_type == allowed for allowed in ALLOWED_CONTENT_TYPES):
+        return True
+    # Some feeds return non-standard but still-safe XML-ish content-types.
+    if "xml" in content_type or "rss" in content_type or "atom" in content_type:
+        return True
+    return False
 
 
 def _html_to_text(html: str) -> tuple[str, Optional[str]]:
@@ -151,7 +156,13 @@ async def _fetch_once(client: httpx.AsyncClient, url: str) -> dict[str, Any]:
 
     content_type = res.headers.get("content-type") or ""
     if not _content_type_allowed(content_type):
-        raise HTTPException(status_code=415, detail="unsupported_content_type")
+        raise HTTPException(
+            status_code=415,
+            detail={
+                "error": "unsupported_content_type",
+                "content_type": (content_type or "").strip(),
+            },
+        )
 
     # Streaming byte limit enforcement
     total = 0

--- a/services/assistance/web-fetcher/main.py
+++ b/services/assistance/web-fetcher/main.py
@@ -129,7 +129,18 @@ def _html_to_text(html: str) -> tuple[str, Optional[str]]:
 async def _fetch_once(client: httpx.AsyncClient, url: str) -> dict[str, Any]:
     _enforce_ssrf(url)
 
-    res = await client.get(url)
+    try:
+        res = await client.get(url)
+    except httpx.RequestError as e:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "upstream_request_failed",
+                "url": url,
+                "exception": e.__class__.__name__,
+                "message": str(e),
+            },
+        )
 
     # Handle redirects manually so we can SSRF-check each hop.
     if res.status_code in (301, 302, 303, 307, 308):


### PR DESCRIPTION
Backend-only enhancement.

- Persist deduped fetched RSS/Atom items into Google Sheet tab 'news_items' (snapshot write via values_update).
- On cache-miss (e.g. after restart), current_news_get loads from 'news_items' (force_fetch=false) instead of re-fetching feeds.
- current_news_refresh continues to force live fetch and then overwrites 'news_items'.

Sys_kv:
- current_news.items.sheet_name (default news_items)
- current_news.items.spreadsheet_id (default system spreadsheet)
- current_news.items.max_rows (default 500)