### PR TITLE
fix(current-news): reduce THB false positives; retry CNN RSS via http

### DIFF
--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -11753,7 +11753,18 @@ def _topic_match(text: str, keywords: list[str]) -> bool:
     if not s:
         return False
     for k in keywords:
-        if k and k.lower() in s:
+        kk = str(k or "").strip().lower()
+        if not kk:
+            continue
+        if re.fullmatch(r"[a-z0-9]+", kk) and len(kk) <= 3:
+            try:
+                if re.search(r"\b" + re.escape(kk) + r"\b", s):
+                    return True
+            except Exception:
+                if kk in s:
+                    return True
+            continue
+        if kk in s:
             return True
     return False
 
@@ -11791,7 +11802,7 @@ def _build_current_news_context(items: list[dict[str, Any]], topics_cfg: Optiona
         "gold": {"keywords": ["gold", "bullion", "xau"], "limit": 4, "headlines": 3},
         "usd": {"keywords": ["dollar", "usd", "treasury", "yield", "fed"], "limit": 4, "headlines": 3},
         "oil": {"keywords": ["oil", "crude", "brent", "wti", "opec"], "limit": 4, "headlines": 3},
-        "thb": {"keywords": ["thai baht", "baht", "thb", "usd/thb", "thb/usd", "bank of thailand", "bot"], "limit": 4, "headlines": 3},
+        "thb": {"keywords": ["thai baht", "baht", "thb", "usd/thb", "thb/usd", "bank of thailand"], "limit": 4, "headlines": 3},
     }
 
     merged: dict[str, dict[str, Any]] = {k: dict(v) for k, v in defaults.items()}

--- a/services/assistance/web-fetcher/main.py
+++ b/services/assistance/web-fetcher/main.py
@@ -131,6 +131,21 @@ def _html_to_text(html: str) -> tuple[str, Optional[str]]:
     return text.strip(), title
 
 
+def _fallback_urls_for_upstream(url: str) -> list[str]:
+    parts = urlsplit(url)
+    host = (parts.hostname or "").strip().lower()
+    if not host:
+        return []
+    if host != "rss.cnn.com":
+        return []
+    if parts.scheme.lower() == "https":
+        try:
+            return [urlunsplit(parts._replace(scheme="http"))]
+        except Exception:
+            return []
+    return []
+
+
 async def _fetch_once(client: httpx.AsyncClient, url: str) -> dict[str, Any]:
     _enforce_ssrf(url)
 
@@ -212,11 +227,30 @@ async def fetch(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
     }
 
     async with httpx.AsyncClient(timeout=timeout, headers=headers, follow_redirects=False, verify=CA_BUNDLE) as client:
-        current = url
-        for _ in range(MAX_REDIRECTS + 1):
-            result = await _fetch_once(client, current)
-            if not result.get("redirect"):
-                return {"ok": True, **result}
-            current = str(result["location"])
+        def _is_retryable_upstream_error(exc: HTTPException) -> bool:
+            try:
+                return exc.status_code == 502 and isinstance(exc.detail, dict) and exc.detail.get("error") == "upstream_request_failed"
+            except Exception:
+                return False
 
-        raise HTTPException(status_code=508, detail="too_many_redirects")
+        attempts = [url] + _fallback_urls_for_upstream(url)
+        last_exc: Optional[HTTPException] = None
+
+        for attempt_url in attempts:
+            current = attempt_url
+            try:
+                for _ in range(MAX_REDIRECTS + 1):
+                    result = await _fetch_once(client, current)
+                    if not result.get("redirect"):
+                        return {"ok": True, **result}
+                    current = str(result["location"])
+                raise HTTPException(status_code=508, detail="too_many_redirects")
+            except HTTPException as e:
+                last_exc = e
+                if attempt_url != attempts[-1] and _is_retryable_upstream_error(e):
+                    continue
+                raise
+
+        if last_exc is not None:
+            raise last_exc
+        raise HTTPException(status_code=502, detail="upstream_request_failed")


### PR DESCRIPTION
Backend-only.

A) Topic tuning:
- Tighten _topic_match: for short alphanumeric keywords (<=3 chars), require word-boundary match to prevent substring false positives.
- Remove overly-generic fallback default keyword 'bot' from THB topic.

B) CNN fallback:
- In web-fetcher, if fetching rss.cnn.com via https fails with upstream_request_failed, retry once via http before returning 502.

No API shape changes; debug output should improve by reducing false matches and decreasing CNN feed failures.