### PR TITLE
fix(current-news): Thai refresh trigger

### DIFF
--- a/services/assistance/jarvis-backend/jarvis/current_news_skill.py
+++ b/services/assistance/jarvis-backend/jarvis/current_news_skill.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Optional
+
+from fastapi import WebSocket
+
+
+async def handle_current_news_trigger(
+    ws: WebSocket,
+    text: str,
+    *,
+    get_cached_ctx: Callable[[], Optional[dict[str, Any]]],
+    refresh_ctx: Callable[[bool], Awaitable[dict[str, Any]]],
+    render_brief: Callable[[dict[str, Any]], str],
+) -> bool:
+    s = " ".join(str(text or "").strip().lower().split())
+    if not s:
+        return False
+
+    wants_refresh = any(
+        p in s
+        for p in (
+            "refresh current news",
+            "current news refresh",
+            "refresh news",
+            "update current news",
+            "current news update",
+            "อัปเดตข่าวปัจจุบัน",
+            "อัปเดตข่าว",
+            "รีเฟรชข่าว",
+            "รีเฟรช ข่าว",
+            "ข่าวปัจจุบัน อัปเดต",
+            "ข่าวปัจจุบันอัปเดต",
+        )
+    )
+    wants_sources = "list sources" in s or s == "sources"
+    wants_details = s.startswith("details ") or s.startswith("detail ")
+    is_trigger = (
+        ("current news" in s)
+        or ("cnn news" in s)
+        or ("thai baht" in s)
+        or (" baht" in f" {s}")
+        or ("thb" in s)
+        or wants_refresh
+        or wants_details
+        or wants_sources
+    )
+    if not is_trigger:
+        return False
+
+    ctx = get_cached_ctx()
+    if wants_refresh or ctx is None:
+        ctx = await refresh_ctx(bool(wants_refresh))
+
+    if not isinstance(ctx, dict):
+        return False
+
+    if wants_sources:
+        await ws.send_json(
+            {
+                "type": "current_news_sources",
+                "sources": ctx.get("sources") or [],
+                "updated_at": ctx.get("updated_at"),
+            }
+        )
+        return True
+
+    if wants_details:
+        topic = str(s.split(" ", 1)[1] if " " in s else "").strip()
+        topics = ctx.get("topics") if isinstance(ctx.get("topics"), dict) else {}
+        key_map = {
+            "iran": "iran_war",
+            "iran war": "iran_war",
+            "war": "iran_war",
+            "gold": "gold",
+            "dollar": "usd",
+            "usd": "usd",
+            "oil": "oil",
+            "baht": "thb",
+            "thai baht": "thb",
+            "thb": "thb",
+            "usd/thb": "thb",
+        }
+        chosen = key_map.get(topic, "")
+        if chosen and isinstance(topics, dict) and isinstance(topics.get(chosen), dict):
+            await ws.send_json(
+                {"type": "current_news_details", "topic": chosen, "data": topics.get(chosen), "updated_at": ctx.get("updated_at")}
+            )
+        else:
+            await ws.send_json(
+                {
+                    "type": "current_news_details",
+                    "topic": topic,
+                    "error": "unknown_topic",
+                    "hint": "Try: details iran | details gold | details usd | details oil",
+                }
+            )
+        return True
+
+    brief = render_brief(ctx)
+    await ws.send_json({"type": "current_news", "brief": brief, "context": ctx, "updated_at": ctx.get("updated_at")})
+    return True

--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -29,6 +29,7 @@ from jarvis import memo_sheet
 from jarvis import memo_enrich
 from jarvis import daily_brief
 from jarvis import sheets_utils
+from jarvis import current_news_skill
 from jarvis import tools_router
 
 from routes.google_tasks import create_router as _create_google_tasks_router
@@ -12224,101 +12225,26 @@ async def _refresh_current_news_cache(
 
 
 async def _handle_current_news_trigger(ws: WebSocket, text: str) -> bool:
-    s = " ".join(str(text or "").strip().lower().split())
-    if not s:
-        return False
+    def _get_cached_ctx() -> Optional[dict[str, Any]]:
+        cached = _get_news_cache("current-news")
+        if cached and isinstance(cached.get("payload"), dict):
+            return cached["payload"]
+        return None
 
-    wants_refresh = any(
-        p in s
-        for p in (
-            "refresh current news",
-            "current news refresh",
-            "refresh news",
-            "update current news",
-            "current news update",
-            "อัปเดตข่าวปัจจุบัน",
-            "อัปเดตข่าว",
-            "รีเฟรชข่าว",
-            "รีเฟรช ข่าว",
-            "ข่าวปัจจุบัน อัปเดต",
-            "ข่าวปัจจุบันอัปเดต",
-        )
-    )
-    wants_sources = "list sources" in s or s == "sources"
-    wants_details = s.startswith("details ") or s.startswith("detail ")
-    is_trigger = (
-        ("current news" in s)
-        or ("cnn news" in s)
-        or ("thai baht" in s)
-        or (" baht" in f" {s}")
-        or ("thb" in s)
-        or wants_refresh
-        or wants_details
-        or wants_sources
-    )
-    if not is_trigger:
-        return False
-
-    cached = _get_news_cache("current-news")
-    ctx: Optional[dict[str, Any]] = None
-    if cached and isinstance(cached.get("payload"), dict):
-        ctx = cached["payload"]
-
-    if wants_refresh or ctx is None:
+    async def _refresh(force_fetch: bool) -> dict[str, Any]:
         sys_kv = getattr(ws.state, "sys_kv", None)
-        ctx = await _refresh_current_news_cache(
+        return await _refresh_current_news_cache(
             sys_kv=sys_kv if isinstance(sys_kv, dict) else None,
-            force_fetch=bool(wants_refresh),
+            force_fetch=bool(force_fetch),
         )
 
-    if not isinstance(ctx, dict):
-        return False
-
-    if wants_sources:
-        await ws.send_json(
-            {
-                "type": "current_news_sources",
-                "sources": ctx.get("sources") or [],
-                "updated_at": ctx.get("updated_at"),
-            }
-        )
-        return True
-
-    if wants_details:
-        topic = str(s.split(" ", 1)[1] if " " in s else "").strip()
-        topics = ctx.get("topics") if isinstance(ctx.get("topics"), dict) else {}
-        key_map = {
-            "iran": "iran_war",
-            "iran war": "iran_war",
-            "war": "iran_war",
-            "gold": "gold",
-            "dollar": "usd",
-            "usd": "usd",
-            "oil": "oil",
-            "baht": "thb",
-            "thai baht": "thb",
-            "thb": "thb",
-            "usd/thb": "thb",
-        }
-        chosen = key_map.get(topic, "")
-        if chosen and isinstance(topics, dict) and isinstance(topics.get(chosen), dict):
-            await ws.send_json(
-                {"type": "current_news_details", "topic": chosen, "data": topics.get(chosen), "updated_at": ctx.get("updated_at")}
-            )
-        else:
-            await ws.send_json(
-                {
-                    "type": "current_news_details",
-                    "topic": topic,
-                    "error": "unknown_topic",
-                    "hint": "Try: details iran | details gold | details usd | details oil",
-                }
-            )
-        return True
-
-    brief = _render_current_news_brief(ctx)
-    await ws.send_json({"type": "current_news", "brief": brief, "context": ctx, "updated_at": ctx.get("updated_at")})
-    return True
+    return await current_news_skill.handle_current_news_trigger(
+        ws,
+        text,
+        get_cached_ctx=_get_cached_ctx,
+        refresh_ctx=_refresh,
+        render_brief=_render_current_news_brief,
+    )
 
 
 @app.get("/current-news/brief")

--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -12236,6 +12236,12 @@ async def _handle_current_news_trigger(ws: WebSocket, text: str) -> bool:
             "refresh news",
             "update current news",
             "current news update",
+            "อัปเดตข่าวปัจจุบัน",
+            "อัปเดตข่าว",
+            "รีเฟรชข่าว",
+            "รีเฟรช ข่าว",
+            "ข่าวปัจจุบัน อัปเดต",
+            "ข่าวปัจจุบันอัปเดต",
         )
     )
     wants_sources = "list sources" in s or s == "sources"


### PR DESCRIPTION
Backend-only.

- Treat common Thai phrases (e.g. 'อัปเดตข่าวปัจจุบัน', 'อัปเดตข่าว', 'รีเฟรชข่าว') as refresh requests in the WS current-news trigger.
- Ensures these phrases set force_fetch=true so the user can refresh in Thai and actually refetch feeds rather than reusing cached/persisted context.