### PR TITLE
Jarvis: remove legacy /jarvis/debug routes

### DIFF
--- a/services/assistance/docs/ACTION.md
+++ b/services/assistance/docs/ACTION.md
@@ -589,18 +589,18 @@ Format SSOT:
 - See: `MEMO.md` (canonical sheet header/order, sys_kv keys, and normalize behavior)
 
 1. **Check effective memo config**
-   - `GET /jarvis/debug/memo`
+   - `GET /jarvis/api/debug/memo`
    - Success looks like:
      - `feature_enabled=true`
      - `memo_enabled=true`
      - non-empty `spreadsheet_id` and `sheet_name`
      - `header_error=null`
 2. **If `memo_enabled=false` but you believe sys_kv is set**
-   - `/jarvis/debug/memo` reads from a cached `sys_kv` snapshot.
+   - `/jarvis/api/debug/memo` reads from a cached `sys_kv` snapshot.
    - Force a refresh by calling:
      - `POST /jarvis/memo/header/normalize`
    - Then re-check:
-     - `GET /jarvis/debug/memo`
+     - `GET /jarvis/api/debug/memo`
 3. **Append a test memo**
    - `POST /jarvis/memo/add`
    - Success looks like:
@@ -633,7 +633,7 @@ Goal: a single, stable way to answer “how many items are in sheet X?” withou
 
 - **Better name:** `sheet_row_count` (more precise) or `sheet_item_count` (OK if we define “item” clearly).
 - **Where to implement (preferred):** Jarvis backend endpoint + optional Jarvis tool wrapper.
-  - Endpoint: `GET /jarvis/debug/sheet_row_count?spreadsheet_id=<id>&sheet=<tab>&has_header=true`
+  - Endpoint: `GET /jarvis/api/debug/sheet_row_count?spreadsheet_id=<id>&sheet=<tab>&has_header=true`
   - Returns:
     - `ok`
     - `spreadsheet_id`, `sheet`
@@ -646,19 +646,19 @@ Goal: a single, stable way to answer “how many items are in sheet X?” withou
   - It can be protected by `_require_api_token_if_configured`.
 - **How we’ll use it (when deployed):**
   - Memo rows:
-    - `GET /jarvis/debug/sheet_row_count?sheet=memo&has_header=true`
+    - `GET /jarvis/api/debug/sheet_row_count?sheet=memo&has_header=true`
   - Logs rows:
-    - `GET /jarvis/debug/sheet_row_count?sheet=logs&has_header=true`
+    - `GET /jarvis/api/debug/sheet_row_count?sheet=logs&has_header=true`
 
 ### Check counts (single call)
-- `GET /jarvis/debug/counts`
+- `GET /jarvis/api/debug/counts`
 - Expected fields:
   - `memory.count` (number of enabled memory items loaded)
   - `memory.cached_count` (may be 0 if not preloaded yet)
   - `memo.rows` (number of memo rows excluding header)
   - `memo.sheet` / `memo.spreadsheet_id` (where it wrote)
 
-### If `/jarvis/debug/counts` is 404
+### If `/jarvis/api/debug/counts` is 404
 - This usually means the deployed container hasn’t picked up the latest code yet.
 - Fallback checks:
   1. **Memory count (backend prewarm)**

--- a/services/assistance/docs/JARVIS_MODULES.md
+++ b/services/assistance/docs/JARVIS_MODULES.md
@@ -27,7 +27,7 @@ Invariants / safety notes:
 
 Smoke test:
 - `POST /jarvis/memo/header/normalize`
-- Then `GET /jarvis/debug/memo` to confirm header matches expected schema.
+- Then `GET /jarvis/api/debug/memo` to confirm header matches expected schema.
 
 
 ## jarvis/sheets_utils.py

--- a/services/assistance/docs/MEMO.md
+++ b/services/assistance/docs/MEMO.md
@@ -57,7 +57,7 @@ Notes:
 
 - The backend normalizer rewrites `A1:J1` and best-effort clears `K1` (and beyond) to prevent stray manual header columns.
 - Debug and maintenance endpoints treat the canonical header as `A:J`:
-  - `GET /jarvis/debug/memo` returns `header` read from `A1:J1`.
+  - `GET /jarvis/api/debug/memo` returns `header` read from `A1:J1`.
   - `POST /jarvis/memo/header/normalize` returns `before`/`after` read from `A1:J1`.
 
 ## Flow diagram

--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -4107,8 +4107,6 @@ def oauth_callback_last() -> dict[str, Any]:
     return {"ok": True, "last": dict(_OAUTH_CALLBACK_LAST)}
 
 
-@app.get("/debug/status")
-@app.get("/jarvis/debug/status")
 @app.get("/api/debug/status")
 @app.get("/jarvis/api/debug/status")
 async def debug_status() -> dict[str, Any]:
@@ -14243,8 +14241,8 @@ def health() -> dict[str, Any]:
     }
 
 
-@app.get("/debug/tools")
-@app.get("/jarvis/debug/tools")
+@app.get("/api/debug/tools")
+@app.get("/jarvis/api/debug/tools")
 def debug_tools() -> dict[str, Any]:
     sys_kv = _sys_kv_snapshot()
     tools = _mcp_tool_declarations()
@@ -14268,8 +14266,8 @@ def debug_tools() -> dict[str, Any]:
     return {"ok": True, "enabled": enabled, "env": env, "tools": names}
 
 
-@app.get("/debug/memo")
-@app.get("/jarvis/debug/memo")
+@app.get("/api/debug/memo")
+@app.get("/jarvis/api/debug/memo")
 async def debug_memo() -> dict[str, Any]:
     sys_kv = _sys_kv_snapshot()
 
@@ -14323,8 +14321,8 @@ async def debug_memo() -> dict[str, Any]:
     }
 
 
-@app.get("/debug/counts")
-@app.get("/jarvis/debug/counts")
+@app.get("/api/debug/counts")
+@app.get("/jarvis/api/debug/counts")
 async def debug_counts() -> dict[str, Any]:
     sys_kv = _sys_kv_snapshot()
 
@@ -15216,10 +15214,16 @@ async def daily_brief() -> dict[str, Any]:
     return {"ok": True, "brief": await _render_daily_brief(DEFAULT_USER_ID)}
 
 
-@app.get("/debug/agents")
+@app.get("/api/debug/agents")
+@app.get("/jarvis/api/debug/agents")
 def debug_agents() -> dict[str, Any]:
     agents = _agents_snapshot()
     triggers = _agent_triggers_snapshot()
+    pending: dict[str, Any] = {}
+    try:
+        pending = _pending_snapshot()
+    except Exception:
+        pass
     return {
         "ok": True,
         "agents_dir": AGENTS_DIR,
@@ -15227,6 +15231,7 @@ def debug_agents() -> dict[str, Any]:
         "agents": agents,
         "triggers": triggers,
         "continuation_window_seconds": AGENT_CONTINUE_WINDOW_SECONDS,
+        "pending": pending,
     }
 
 

--- a/services/assistance/jarvis-frontend/App.tsx
+++ b/services/assistance/jarvis-frontend/App.tsx
@@ -881,17 +881,10 @@ export default function App() {
         } catch {
           res = null;
         }
+
         if (!res || !res.ok) {
-          try {
-            res = await fetch("/jarvis/debug/status", { cache: "no-store" });
-          } catch {
-            res = null;
-          }
+          throw new Error(`status_http_${res ? res.status : "fetch_failed"}`);
         }
-        if (!res || !res.ok) {
-          res = await fetch("/debug/status", { cache: "no-store" });
-        }
-        if (!res) throw new Error("deps_status_fetch_failed");
 
         const bodyText = await res.text();
         const trimmed = String(bodyText || "").trim();
@@ -919,31 +912,7 @@ export default function App() {
       cancelled = true;
       window.clearInterval(t);
     };
-  }, [hasKey, statusDetailsOpen, depsStatusRefreshNonce]);
-
-  const getSeqCompletedTasks = () => {
-    const completedBlocks = String(seqCompletedNotes || "")
-      .split(/\n\s*---\s*\n/g)
-      .map((b) => b.trim())
-      .filter(Boolean);
-    return completedBlocks.length ? completedBlocks.map((notes) => ({ notes })) : undefined;
-  };
-
-  const applySeqResponse = (res: any) => {
-    setSeqNotes(res.notes);
-    setSeqNextText(res.next_step_text);
-    setSeqNextIndex(res.next_step_index);
-    setSeqTemplate(res.template);
-  };
-
-  const handleSeqSuggest = async () => {
-    setSeqBusy(true);
-    setSeqError("");
-    try {
-      const completed_tasks = getSeqCompletedTasks();
-      const res = await sequentialApplyAndSuggest({ mode: "suggest", notes: seqNotes, completed_tasks });
-      applySeqResponse(res);
-    } catch (e: any) {
+  },
       setSeqError(String(e?.message || e || "suggest_failed"));
       setSeqNextText(null);
       setSeqNextIndex(null);


### PR DESCRIPTION
Hard remove legacy debug routes and tidy references.\n\n- Backend: remove /debug/* and /jarvis/debug/* route decorators; keep only /api/debug/* and /jarvis/api/debug/*\n- Frontend: remove fallback fetch to /jarvis/debug/status\n- Docs: update references to canonical /jarvis/api/debug/*\n\nNote: built dist asset may still contain old string until next frontend build; source references are cleaned.