### PR TITLE
Jarvis frontend: fix Vite build parse error

### DIFF
--- a/services/assistance/jarvis-frontend/App.tsx
+++ b/services/assistance/jarvis-frontend/App.tsx
@@ -912,15 +912,7 @@ export default function App() {
       cancelled = true;
       window.clearInterval(t);
     };
-  },
-      setSeqError(String(e?.message || e || "suggest_failed"));
-      setSeqNextText(null);
-      setSeqNextIndex(null);
-      setSeqTemplate(null);
-    } finally {
-      setSeqBusy(false);
-    }
-  };
+  }, [hasKey, statusDetailsOpen, depsStatusRefreshNonce]);
 
   const handleSeqApply = async () => {
     if (seqNextIndex == null) return;


### PR DESCRIPTION
Fix malformed useEffect call in App.tsx that broke Vite/esbuild parsing during  (missing dependency array / closing ).