### PR TITLE
Jarvis frontend: canonical /jarvis base + voice cmd cfg path

### DIFF
--- a/services/assistance/jarvis-frontend/App.tsx
+++ b/services/assistance/jarvis-frontend/App.tsx
@@ -106,9 +106,11 @@ export default function App() {
 
   const backendCandidates = useCallback((): string[] => {
     const override = String((import.meta as any).env?.VITE_JARVIS_HTTP_URL as string | undefined || "").trim();
-    const normOverride = override ? override.trim().replace(/\/+$/, "").replace(/^\s+|\s+$/g, "") : "";
+    let normOverride = override ? override.trim().replace(/\/+$/, "").replace(/^\s+|\s+$/g, "") : "";
+    if (normOverride.endsWith("/jarvis/api")) normOverride = normOverride.slice(0, -"/api".length);
+    else if (normOverride.endsWith("/api")) normOverride = normOverride.slice(0, -"/api".length);
     const isJarvisSubpath = location.pathname.startsWith("/jarvis");
-    const defaults = isJarvisSubpath ? ["/jarvis/api", "/jarvis", ""] : ["", "/jarvis/api", "/jarvis"];
+    const defaults = isJarvisSubpath ? ["/jarvis"] : ["", "/jarvis", "/jarvis/api"];
     const out = normOverride ? [normOverride, ...defaults] : defaults;
 
     const seen = new Set<string>();

--- a/services/assistance/jarvis-frontend/CADDY_JARVIS_SNIPPET.md
+++ b/services/assistance/jarvis-frontend/CADDY_JARVIS_SNIPPET.md
@@ -8,25 +8,23 @@ Assumes:
 
 ```caddy
 assistance.idc1.surf-thailand.com {
-  # WebSocket endpoint to backend (strip /jarvis prefix)
-  handle_path /jarvis/ws/* {
+  # WebSocket endpoint to backend (do NOT strip; backend expects /ws/*)
+  handle /jarvis/ws/* {
     reverse_proxy 127.0.0.1:18018
   }
 
-  # Backend HTTP API (strip /jarvis/api prefix)
-  handle_path /jarvis/api/* {
+  # Backend HTTP API (do NOT strip; backend expects /api/*)
+  handle /jarvis/api/* {
     reverse_proxy 127.0.0.1:18018
   }
 
   # All other /jarvis paths go to the SPA frontend
-  handle_path /jarvis/* {
+  handle /jarvis/* {
     reverse_proxy 127.0.0.1:18080
   }
 }
 ```
 
 Notes:
-- `handle_path` strips the matched prefix before proxying.
-  - `/jarvis/ws/live` becomes `/ws/live` at the backend.
-  - `/jarvis/...` becomes `/...` at the frontend.
+- `handle` does not rewrite the request path.
 - WebSockets work automatically through `reverse_proxy`.

--- a/services/assistance/jarvis-frontend/services/liveService.ts
+++ b/services/assistance/jarvis-frontend/services/liveService.ts
@@ -209,8 +209,8 @@ export class LiveService {
 		const isJarvisSubpath = location.pathname.startsWith("/jarvis");
 		try {
 			const candidates = isJarvisSubpath
-				? ["/jarvis/api/config/voice_commands", "/jarvis/config/voice_commands", "/config/voice_commands"]
-				: ["/config/voice_commands", "/jarvis/api/config/voice_commands", "/jarvis/config/voice_commands"];
+				? ["/jarvis/config/voice_commands", "/config/voice_commands"]
+				: ["/config/voice_commands", "/jarvis/config/voice_commands"];
 			let j: any = null;
 			for (const u of candidates) {
 				try {


### PR DESCRIPTION
- When UI is served under /jarvis, stop using /jarvis/api as a backend base candidate (prevents bad /jarvis/api/logs/* requests)\n- Normalize VITE_JARVIS_HTTP_URL if it ends with /api\n- Voice commands config fetch: stop probing /jarvis/api/config/voice_commands; use /jarvis/config/voice_commands\n- Update Caddy snippet doc to reflect handle vs handle_path behavior\n\nNo backend /api aliases added.