### PR TITLE
Jarvis: consolidate backend HTTP under /jarvis/api

### DIFF
--- a/services/assistance/jarvis-frontend/App.tsx
+++ b/services/assistance/jarvis-frontend/App.tsx
@@ -107,10 +107,8 @@ export default function App() {
   const backendCandidates = useCallback((): string[] => {
     const override = String((import.meta as any).env?.VITE_JARVIS_HTTP_URL as string | undefined || "").trim();
     let normOverride = override ? override.trim().replace(/\/+$/, "").replace(/^\s+|\s+$/g, "") : "";
-    if (normOverride.endsWith("/jarvis/api")) normOverride = normOverride.slice(0, -"/api".length);
-    else if (normOverride.endsWith("/api")) normOverride = normOverride.slice(0, -"/api".length);
     const isJarvisSubpath = location.pathname.startsWith("/jarvis");
-    const defaults = isJarvisSubpath ? ["/jarvis"] : ["", "/jarvis", "/jarvis/api"];
+    const defaults = isJarvisSubpath ? ["/jarvis/api"] : ["", "/jarvis/api", "/jarvis"];
     const out = normOverride ? [normOverride, ...defaults] : defaults;
 
     const seen = new Set<string>();

--- a/services/assistance/jarvis-frontend/CADDY_JARVIS_SNIPPET.md
+++ b/services/assistance/jarvis-frontend/CADDY_JARVIS_SNIPPET.md
@@ -8,23 +8,23 @@ Assumes:
 
 ```caddy
 assistance.idc1.surf-thailand.com {
-  # WebSocket endpoint to backend (do NOT strip; backend expects /ws/*)
-  handle /jarvis/ws/* {
+  # WebSocket endpoint to backend
+  handle_path /jarvis/ws/* {
     reverse_proxy 127.0.0.1:18018
   }
 
-  # Backend HTTP API (do NOT strip; backend expects /api/*)
-  handle /jarvis/api/* {
+  # Backend HTTP (single contract: /jarvis/api/*)
+  handle_path /jarvis/api/* {
     reverse_proxy 127.0.0.1:18018
   }
 
   # All other /jarvis paths go to the SPA frontend
-  handle /jarvis/* {
+  handle_path /jarvis/* {
     reverse_proxy 127.0.0.1:18080
   }
 }
 ```
 
 Notes:
-- `handle` does not rewrite the request path.
+- `handle_path` strips the matched prefix before proxying.
 - WebSockets work automatically through `reverse_proxy`.

--- a/services/assistance/jarvis-frontend/services/liveService.ts
+++ b/services/assistance/jarvis-frontend/services/liveService.ts
@@ -209,8 +209,8 @@ export class LiveService {
 		const isJarvisSubpath = location.pathname.startsWith("/jarvis");
 		try {
 			const candidates = isJarvisSubpath
-				? ["/jarvis/config/voice_commands", "/config/voice_commands"]
-				: ["/config/voice_commands", "/jarvis/config/voice_commands"];
+				? ["/jarvis/api/config/voice_commands", "/config/voice_commands"]
+				: ["/config/voice_commands", "/jarvis/api/config/voice_commands"];
 			let j: any = null;
 			for (const u of candidates) {
 				try {

--- a/services/assistance/jarvis-frontend/services/sequentialService.ts
+++ b/services/assistance/jarvis-frontend/services/sequentialService.ts
@@ -72,7 +72,7 @@ function getBackendHttpBaseUrl(): string {
 
   const isJarvisSubpath = location.pathname.startsWith("/jarvis");
   if (isJarvisSubpath) {
-    return `${location.origin}/jarvis`;
+    return `${location.origin}/jarvis/api`;
   }
 
   return `${location.protocol}//${location.hostname}:8018`;


### PR DESCRIPTION
Standardize public routing contract:\n\n- Backend HTTP: always under /jarvis/api/* (single prefix)\n- WS remains /jarvis/ws/*\n\nFrontend changes:\n- backendCandidates defaults to /jarvis/api when UI served under /jarvis\n- voice command config fetch uses /jarvis/api/config/voice_commands\n- sequentialService uses base /jarvis/api\n\nDocs:\n- update CADDY_JARVIS_SNIPPET.md to use handle_path for /jarvis/api/* and /jarvis/ws/* (prefix-stripping).\n\nFollow-up required on host: ensure Caddy strips /jarvis/api (and /jarvis for ws) to match backend internal paths.