### PR TITLE
Jarvis: readiness phases + header indicator

### DIFF
--- a/services/assistance/jarvis-backend/main.py
+++ b/services/assistance/jarvis-backend/main.py
@@ -18418,6 +18418,11 @@ async def _gemini_to_ws_loop(ws: WebSocket, session: Any) -> None:
 async def ws_live(ws: WebSocket) -> None:
     await ws.accept()
 
+    try:
+        await _ws_send_json(ws, {"type": "readiness", "phase": "transport_connected", "instance_id": INSTANCE_ID})
+    except Exception:
+        pass
+
     user_id = DEFAULT_USER_ID
     _ws_by_user.setdefault(user_id, set()).add(ws)
 
@@ -18710,6 +18715,23 @@ async def ws_live(ws: WebSocket) -> None:
         except Exception:
             pass
 
+        try:
+            await _ws_send_json(
+                ws,
+                {
+                    "type": "readiness",
+                    "phase": "bootstrap_ready",
+                    "instance_id": INSTANCE_ID,
+                    "sys_kv_loaded": isinstance(sys_kv, dict) and bool(sys_kv),
+                    "system_sheet_valid": True,
+                    "macros_reloaded": macros_reloaded,
+                    "memory_cached": bool(_get_cached_sheet_memory()),
+                    "knowledge_cached": bool(_get_cached_sheet_knowledge()),
+                },
+            )
+        except Exception:
+            pass
+
         lang = str(getattr(ws.state, "user_lang", "") or "").strip() or _lang_from_ws(ws)
 
         cached = _get_cached_sheet_memory()
@@ -18719,6 +18741,22 @@ async def ws_live(ws: WebSocket) -> None:
         cached_k = _get_cached_sheet_knowledge()
         if isinstance(cached_k, dict):
             _apply_cached_sheet_knowledge_to_ws(ws, cached_k)
+
+        try:
+            mem_items = getattr(ws.state, "memory_items", None)
+            know_items = getattr(ws.state, "knowledge_items", None)
+            await _ws_send_json(
+                ws,
+                {
+                    "type": "readiness",
+                    "phase": "context_cached",
+                    "instance_id": INSTANCE_ID,
+                    "memory_n": len(mem_items) if isinstance(mem_items, list) else 0,
+                    "knowledge_n": len(know_items) if isinstance(know_items, list) else 0,
+                },
+            )
+        except Exception:
+            pass
 
         # Cache-first mode: do not auto-load sheets here. Use `Reload System`.
         # Emit status based on cache only, but suppress duplicates on rapid reconnects.
@@ -19125,6 +19163,19 @@ async def ws_live(ws: WebSocket) -> None:
                         ws.state.local_only = False
                     except Exception:
                         pass
+
+                    try:
+                        await _ws_send_json(
+                            ws,
+                            {
+                                "type": "readiness",
+                                "phase": "model_ready",
+                                "instance_id": INSTANCE_ID,
+                                "model": str(model or ""),
+                            },
+                        )
+                    except Exception:
+                        pass
                     await _ws_send_json(
                         ws,
                         {
@@ -19207,6 +19258,11 @@ async def ws_live(ws: WebSocket) -> None:
                     pass
                 try:
                     ws.state.gemini_disconnected_at_ms = int(time.time() * 1000)
+                except Exception:
+                    pass
+
+                try:
+                    await _ws_send_json(ws, {"type": "readiness", "phase": "model_disconnected", "instance_id": INSTANCE_ID})
                 except Exception:
                     pass
 

--- a/services/assistance/jarvis-frontend/App.tsx
+++ b/services/assistance/jarvis-frontend/App.tsx
@@ -44,6 +44,9 @@ export default function App() {
   const [wsLogText, setWsLogText] = useState<string>("");
   const [wsLogErr, setWsLogErr] = useState<string>("");
 
+  const [readinessPhase, setReadinessPhase] = useState<string>("");
+  const [readinessSinceMs, setReadinessSinceMs] = useState<number>(0);
+
   const [composerText, setComposerText] = useState<string>("");
   const [seqNotes, setSeqNotes] = useState<string>("");
   const [seqCompletedNotes, setSeqCompletedNotes] = useState<string>("");
@@ -295,6 +298,16 @@ export default function App() {
     liveService.current = new LiveService();
     liveService.current.onStateChange = setState;
     liveService.current.onVolume = setVolume;
+    liveService.current.onReadiness = (ev) => {
+      try {
+        const phase = String(ev?.phase || "").trim();
+        if (!phase) return;
+        setReadinessPhase(phase);
+        setReadinessSinceMs((prev) => (prev ? prev : typeof ev?.ts === "number" ? ev.ts : Date.now()));
+      } catch {
+        // ignore
+      }
+    };
     liveService.current.onPendingEvent = (ev) => {
       try {
         const event = String((ev as any)?.event || "").trim();
@@ -390,6 +403,13 @@ export default function App() {
       }
     };
   }, [hasKey, appendUiLogEntry, previewPending, refreshPending, scheduleUiLogFlush]);
+
+  useEffect(() => {
+    if (state !== ConnectionState.CONNECTED) {
+      setReadinessPhase("");
+      setReadinessSinceMs(0);
+    }
+  }, [state]);
 
   useAutoScroll(logScrollRef, logStickToBottomRef, [messages, showDebugLogs]);
   useAutoScroll(outputScrollRef, outputStickToBottomRef, [outputDialog]);
@@ -1239,6 +1259,8 @@ export default function App() {
         setStatusDetailsOpen={setStatusDetailsOpen}
         systemCounts={systemCounts}
         audioStatus={audioStatus}
+        readinessPhase={readinessPhase}
+        readinessSinceMs={readinessSinceMs}
         depsStatusError={depsStatusError}
         depsStatus={depsStatus}
         setDepsStatusRefreshNonce={setDepsStatusRefreshNonce}

--- a/services/assistance/jarvis-frontend/components/app/LeftPanel.tsx
+++ b/services/assistance/jarvis-frontend/components/app/LeftPanel.tsx
@@ -32,6 +32,8 @@ export function LeftPanel(props: {
 
   systemCounts: { memory: number; knowledge: number; ok: boolean };
   audioStatus: { ok: boolean; lastConn: number; lastAudioUnavailable: number };
+  readinessPhase: string;
+  readinessSinceMs: number;
 
   depsStatusError: string;
   depsStatus: any;
@@ -84,6 +86,8 @@ export function LeftPanel(props: {
     setStatusDetailsOpen,
     systemCounts,
     audioStatus,
+    readinessPhase,
+    readinessSinceMs,
     depsStatusError,
     depsStatus,
     setDepsStatusRefreshNonce,
@@ -112,6 +116,17 @@ export function LeftPanel(props: {
     isTalking,
     handleToggleTalk,
   } = props;
+
+  const readinessText = React.useMemo(() => {
+    const p = String(readinessPhase || "").trim();
+    if (!p) return "";
+    const base = `readiness: ${p}`;
+    const since = Number(readinessSinceMs || 0);
+    if (!since) return base;
+    const elapsed = Math.max(0, Date.now() - since);
+    const s = (elapsed / 1000).toFixed(elapsed < 10_000 ? 1 : 0);
+    return `${base} (${s}s)`;
+  }, [readinessPhase, readinessSinceMs]);
 
   const [uiCardActionByMsgId, setUiCardActionByMsgId] = React.useState<
     Record<string, { busy: boolean; status: "idle" | "ok" | "error"; message?: string }>
@@ -204,6 +219,12 @@ export function LeftPanel(props: {
               </button>
             )}
           </div>
+
+          {!!readinessText && (
+            <div className="mt-2 text-[11px] font-mono text-slate-400 border border-slate-800 rounded-lg bg-slate-950/20 px-2 py-1">
+              {readinessText}
+            </div>
+          )}
 
           {statusDetailsOpen && (
             <div className="mt-2 space-y-2">

--- a/services/assistance/jarvis-frontend/services/liveService.ts
+++ b/services/assistance/jarvis-frontend/services/liveService.ts
@@ -544,6 +544,7 @@ export class LiveService {
   public onStateChange: (state: ConnectionState) => void = () => {};
   public onMessage: (msg: MessageLog) => void = () => {};
   public onPendingEvent: (ev: any) => void = () => {};
+  public onReadiness: (ev: { phase: string; detail?: any; ts: number }) => void = () => {};
   public onVolume: (vol: number) => void = () => {};
   public onCarsIngestResult: (ev: CarsIngestResult) => void = () => {};
 
@@ -673,6 +674,7 @@ export class LiveService {
 				}, 25000);
 			} catch {
 			}
+        this.onReadiness({ phase: "ws_open", ts: Date.now() });
         this.onMessage({
           id: `${Date.now()}_ws_open`,
           role: "system",
@@ -714,6 +716,11 @@ export class LiveService {
           }
         }
         this.onStateChange(ConnectionState.DISCONNECTED);
+        try {
+          this.onReadiness({ phase: "ws_closed", detail: { code: ev.code, reason: ev.reason, wasClean: ev.wasClean }, ts: Date.now() });
+        } catch {
+          // ignore
+        }
         if (!quiet) {
           this.onMessage({
             id: `${Date.now()}_ws_close`,
@@ -733,6 +740,11 @@ export class LiveService {
 			}
         console.error(err);
         this.onStateChange(ConnectionState.ERROR);
+        try {
+          this.onReadiness({ phase: "ws_error", ts: Date.now() });
+        } catch {
+          // ignore
+        }
         this.onMessage({
           id: `${Date.now()}_ws_error`,
           role: "system",
@@ -845,6 +857,16 @@ export class LiveService {
       client_tag: message?.client_tag != null ? String(message.client_tag) : undefined,
       client_id: message?.client_id != null ? String(message.client_id) : undefined,
     };
+
+		if (message?.type === "readiness") {
+			try {
+				const phase = message?.phase != null ? String(message.phase) : "";
+				this.onReadiness({ phase, detail: message, ts: Date.now() });
+			} catch {
+				// ignore
+			}
+			return;
+		}
 
     if (message?.type === "session_resume") {
       const ok = message?.ok === true;


### PR DESCRIPTION
Add explicit readiness phases emitted over WS and a compact header indicator in the WebUI.\n\nBackend:\n- Emit WS messages: type=readiness phase=transport_connected/bootstrap_ready/context_cached/model_ready/model_disconnected\n\nFrontend:\n- LiveService forwards readiness events via onReadiness\n- App tracks readinessPhase + readinessSinceMs\n- LeftPanel displays 'readiness: <phase> (Xs)' under System\n\nThis makes reconnect delays observable and actionable.