### PR TITLE
Split idc1-assistance stacks + embed mcp-bundle entrypoint

### DIFF
--- a/.github/workflows/publish-idc1-assistance.yml
+++ b/.github/workflows/publish-idc1-assistance.yml
@@ -75,7 +75,16 @@ jobs:
             file: ./services/assistance/mcp-bundle/Dockerfile
             build_args: ""
             extra_paths: |
+              services/assistance/mcp-bundle/Dockerfile
+              services/assistance/mcp-bundle/entrypoint.sh
+              services/assistance/mcp-bundle/proxy.js
+              services/assistance/mcp-bundle/mcp-config/mcp.json
+              services/assistance/mcp-bundle/mcp-servers/mcp-google-sheets/server.js
+              services/assistance/mcp-bundle/mcp-servers/mcp-google-tasks/server.js
+              services/assistance/mcp-bundle/mcp-servers/mcp-google-calendar/server.js
               services/assistance/mcp-servers/mcp-google-sheets/server.js
+              services/assistance/mcp-servers/mcp-google-tasks/server.js
+              services/assistance/mcp-servers/mcp-google-calendar/server.js
           - name: mcp-image-pipeline
             image: mcp-image-pipeline
             context: ./services/assistance/mcp-image-pipeline

--- a/scripts/deploy-idc1-assistance.sh
+++ b/scripts/deploy-idc1-assistance.sh
@@ -53,6 +53,7 @@ poll_seconds="${POLL_SECONDS:-10}"
 window_seconds="${HEALTH_WINDOW_SECONDS:-120}"
 force_redeploy="${FORCE_REDEPLOY:-0}"
 dry_run="${DRY_RUN:-0}"
+no_pull="${NO_PULL:-0}"
 
 echo "[deploy] repo=${repo} workflow=${workflow_name} branch=${branch} compose=${compose_file}"
 
@@ -444,8 +445,12 @@ detect_changed_services_for_stack() {
     running_image_by_service["${s}"]="$(docker inspect -f '{{.Image}}' "${cid}" 2>/dev/null || true)"
   done
 
-  echo "[deploy] [${stack_name}] Pulling stack images..." >&2
-  docker compose -f "${compose_path}" pull
+  if [[ "${no_pull}" == "1" || "${no_pull}" == "true" || "${no_pull}" == "yes" ]]; then
+    echo "[deploy] [${stack_name}] NO_PULL is set. Skipping image pull." >&2
+  else
+    echo "[deploy] [${stack_name}] Pulling stack images..." >&2
+    docker compose -f "${compose_path}" pull
+  fi
 
   echo "[deploy] [${stack_name}] Determining which services changed..." >&2
   declare -A image_by_service

--- a/scripts/deploy-idc1-assistance.sh
+++ b/scripts/deploy-idc1-assistance.sh
@@ -426,7 +426,7 @@ detect_changed_services_for_stack() {
   local stack_name="$1"
   local compose_path="$2"
 
-  echo "[deploy] [${stack_name}] Collecting current running container image IDs..."
+  echo "[deploy] [${stack_name}] Collecting current running container image IDs..." >&2
   mapfile -t services < <(docker compose -f "${compose_path}" config --services)
 
   if (( ${#services[@]} == 0 )); then
@@ -444,10 +444,10 @@ detect_changed_services_for_stack() {
     running_image_by_service["${s}"]="$(docker inspect -f '{{.Image}}' "${cid}" 2>/dev/null || true)"
   done
 
-  echo "[deploy] [${stack_name}] Pulling stack images..."
+  echo "[deploy] [${stack_name}] Pulling stack images..." >&2
   docker compose -f "${compose_path}" pull
 
-  echo "[deploy] [${stack_name}] Determining which services changed..."
+  echo "[deploy] [${stack_name}] Determining which services changed..." >&2
   declare -A image_by_service
   while IFS=$'\t' read -r svc_name img_ref; do
     if [[ -n "${svc_name}" && -n "${img_ref}" ]]; then
@@ -493,21 +493,21 @@ PY
     fi
 
     if [[ -z "${old_image_id}" ]]; then
-      echo "[deploy] [${stack_name}] Service ${s}: not running -> will start/update (image=${image_ref})"
+      echo "[deploy] [${stack_name}] Service ${s}: not running -> will start/update (image=${image_ref})" >&2
       changed_services+=("${s}")
       continue
     fi
 
     if [[ "${new_image_id}" != "${old_image_id}" ]]; then
-      echo "[deploy] [${stack_name}] Service ${s}: CHANGED old=${old_image_id} new=${new_image_id} image=${image_ref}"
+      echo "[deploy] [${stack_name}] Service ${s}: CHANGED old=${old_image_id} new=${new_image_id} image=${image_ref}" >&2
       changed_services+=("${s}")
     else
-      echo "[deploy] [${stack_name}] Service ${s}: unchanged (image=${image_ref})"
+      echo "[deploy] [${stack_name}] Service ${s}: unchanged (image=${image_ref})" >&2
     fi
   done
 
   if [[ "${force_redeploy}" == "1" || "${force_redeploy}" == "true" || "${force_redeploy}" == "yes" ]]; then
-    echo "[deploy] [${stack_name}] FORCE_REDEPLOY is set. Forcing redeploy even if image digests are unchanged."
+    echo "[deploy] [${stack_name}] FORCE_REDEPLOY is set. Forcing redeploy even if image digests are unchanged." >&2
     changed_services=("${services[@]}")
   fi
 

--- a/scripts/deploy-idc1-assistance.sh
+++ b/scripts/deploy-idc1-assistance.sh
@@ -21,6 +21,12 @@ portainer_endpoint_id="${PORTAINER_ENDPOINT_ID:-2}"
 portainer_stack_name="${PORTAINER_STACK_NAME:-idc1-assistance-dev}"
 portainer_container_name="${PORTAINER_CONTAINER_NAME:-idc1-portainer}"
 
+# Multi-stack mode (comma-separated):
+# - PORTAINER_STACK_NAMES='idc1-assistance-core,idc1-assistance-workers'
+# - COMPOSE_FILES='stacks/idc1-assistance-core/docker-compose.yml,stacks/idc1-assistance-workers/docker-compose.yml'
+portainer_stack_names_csv="${PORTAINER_STACK_NAMES:-}"
+compose_files_csv="${COMPOSE_FILES:-}"
+
 healthcheck_url="${HEALTHCHECK_URL:-http://127.0.0.1:28018/health}"
 healthcheck_container_name="${HEALTHCHECK_CONTAINER_NAME:-${portainer_stack_name}-jarvis-backend-1}"
 
@@ -46,25 +52,41 @@ wait_timeout_seconds="${WAIT_TIMEOUT_SECONDS:-1800}"
 poll_seconds="${POLL_SECONDS:-10}"
 window_seconds="${HEALTH_WINDOW_SECONDS:-120}"
 force_redeploy="${FORCE_REDEPLOY:-0}"
+dry_run="${DRY_RUN:-0}"
 
 echo "[deploy] repo=${repo} workflow=${workflow_name} branch=${branch} compose=${compose_file}"
 
 # Ensure sub-processes (python snippets) see the same compose file.
 export COMPOSE_FILE="${compose_file}"
 
+split_csv() {
+  local s="$1"
+  local -a out=()
+  local item=""
+  IFS=',' read -r -a out <<<"${s}"
+  for item in "${out[@]}"; do
+    item="$(echo "${item}" | xargs)"
+    if [[ -n "${item}" ]]; then
+      echo "${item}"
+    fi
+  done
+}
+
 get_container_id() {
   local service="$1"
+  local stack_name="$2"
+  local compose_path="$3"
   local cid=""
 
   # Prefer docker compose (when containers have compose labels)
-  cid="$(docker compose -f "${compose_file}" ps -q "${service}" 2>/dev/null || true)"
+  cid="$(docker compose -f "${compose_path}" ps -q "${service}" 2>/dev/null || true)"
   if [[ -n "${cid}" ]]; then
     echo "${cid}"
     return 0
   fi
 
   # Fallback: explicit container name convention used by this stack
-  cid="$(docker ps --filter "name=^/${portainer_stack_name}-${service}-1$" --format '{{.ID}}' | head -n 1)"
+  cid="$(docker ps --filter "name=^/${stack_name}-${service}-1$" --format '{{.ID}}' | head -n 1)"
   if [[ -n "${cid}" ]]; then
     echo "${cid}"
     return 0
@@ -74,6 +96,7 @@ get_container_id() {
 }
 
 trigger_portainer_redeploy() {
+  local stack_name="$1"
   if [[ -z "${portainer_api_key}" ]]; then
     echo "[deploy] ERROR: PORTAINER_API_KEY is not set" >&2
     return 1
@@ -101,7 +124,7 @@ trigger_portainer_redeploy() {
     return 1
   fi
 
-  echo "[deploy] Discovering stack id for name=${portainer_stack_name} endpointId=${portainer_endpoint_id}"
+  echo "[deploy] Discovering stack id for name=${stack_name} endpointId=${portainer_endpoint_id}"
   stacks_http="$(curl -sS -k --max-time 30 -o /tmp/portainer_stacks.json -w '%{http_code}' -H "X-API-Key: ${portainer_api_key}" "${base}/api/stacks" || true)"
   if [[ "${stacks_http}" != "200" ]]; then
     echo "[deploy] ERROR: Portainer /api/stacks returned http=${stacks_http}" >&2
@@ -110,7 +133,7 @@ trigger_portainer_redeploy() {
     return 1
   fi
 
-  stack_id="$(STACK_NAME="${portainer_stack_name}" ENDPOINT_ID="${portainer_endpoint_id}" python3 - <<'PY'
+  stack_id="$(STACK_NAME="${stack_name}" ENDPOINT_ID="${portainer_endpoint_id}" python3 - <<'PY'
 import json,os,sys
 
 name=os.environ.get('STACK_NAME','')
@@ -144,7 +167,7 @@ PY
 )"
 
   if [[ -z "${stack_id}" ]]; then
-    echo "[deploy] ERROR: could not find stack id for name=${portainer_stack_name}" >&2
+    echo "[deploy] ERROR: could not find stack id for name=${stack_name}" >&2
     return 1
   fi
 
@@ -399,40 +422,46 @@ while true; do
   sleep "${poll_seconds}"
 done
 
-echo "[deploy] Collecting current running container image IDs..."
-mapfile -t services < <(docker compose -f "${compose_file}" config --services)
+detect_changed_services_for_stack() {
+  local stack_name="$1"
+  local compose_path="$2"
 
-if (( ${#services[@]} == 0 )); then
-  echo "[deploy] ERROR: no services found in compose config" >&2
-  exit 1
-fi
+  echo "[deploy] [${stack_name}] Collecting current running container image IDs..."
+  mapfile -t services < <(docker compose -f "${compose_path}" config --services)
 
-declare -A running_image_by_service
-for s in "${services[@]}"; do
-  cid="$(get_container_id "${s}" || true)"
-  if [[ -z "${cid}" ]]; then
-    running_image_by_service["${s}"]=""
-    continue
+  if (( ${#services[@]} == 0 )); then
+    echo "[deploy] [${stack_name}] ERROR: no services found in compose config" >&2
+    return 2
   fi
-  running_image_by_service["${s}"]="$(docker inspect -f '{{.Image}}' "${cid}" 2>/dev/null || true)"
-done
 
-echo "[deploy] Pulling stack images..."
-docker compose -f "${compose_file}" pull
+  declare -A running_image_by_service
+  for s in "${services[@]}"; do
+    cid="$(get_container_id "${s}" "${stack_name}" "${compose_path}" || true)"
+    if [[ -z "${cid}" ]]; then
+      running_image_by_service["${s}"]=""
+      continue
+    fi
+    running_image_by_service["${s}"]="$(docker inspect -f '{{.Image}}' "${cid}" 2>/dev/null || true)"
+  done
 
-echo "[deploy] Determining which services changed..."
-changed_services=()
-declare -A image_by_service
-while IFS=$'\t' read -r svc_name img_ref; do
-  if [[ -n "${svc_name}" && -n "${img_ref}" ]]; then
-    image_by_service["${svc_name}"]="${img_ref}"
-  fi
-done < <(python3 - <<'PY'
+  echo "[deploy] [${stack_name}] Pulling stack images..."
+  docker compose -f "${compose_path}" pull
+
+  echo "[deploy] [${stack_name}] Determining which services changed..."
+  declare -A image_by_service
+  while IFS=$'\t' read -r svc_name img_ref; do
+    if [[ -n "${svc_name}" && -n "${img_ref}" ]]; then
+      image_by_service["${svc_name}"]="${img_ref}"
+    fi
+  done < <(python3 - <<'PY'
 import json
 import subprocess
 import os
 
-compose_file = os.environ.get("COMPOSE_FILE") or "stacks/idc1-assistance-dev/docker-compose.yml"
+compose_file = os.environ.get("COMPOSE_FILE")
+if not compose_file:
+    raise SystemExit("COMPOSE_FILE not set")
+
 cp = subprocess.run(
     ["docker", "compose", "-f", compose_file, "config", "--format", "json"],
     check=True,
@@ -446,66 +475,125 @@ for name, svc in services.items():
     if img:
         print(f"{name}\t{img}")
 PY
-)
+  )
 
-for s in "${services[@]}"; do
-  image_ref="${image_by_service["${s}"]:-}"
-  if [[ -z "${image_ref}" ]]; then
-    continue
+  changed_services=()
+  for s in "${services[@]}"; do
+    image_ref="${image_by_service["${s}"]:-}"
+    if [[ -z "${image_ref}" ]]; then
+      continue
+    fi
+
+    new_image_id="$(docker image inspect -f '{{.Id}}' "${image_ref}" 2>/dev/null || true)"
+    old_image_id="${running_image_by_service["${s}"]}"
+
+    if [[ -z "${new_image_id}" ]]; then
+      echo "[deploy] [${stack_name}] WARN: could not inspect pulled image for service=${s} image=${image_ref}" >&2
+      continue
+    fi
+
+    if [[ -z "${old_image_id}" ]]; then
+      echo "[deploy] [${stack_name}] Service ${s}: not running -> will start/update (image=${image_ref})"
+      changed_services+=("${s}")
+      continue
+    fi
+
+    if [[ "${new_image_id}" != "${old_image_id}" ]]; then
+      echo "[deploy] [${stack_name}] Service ${s}: CHANGED old=${old_image_id} new=${new_image_id} image=${image_ref}"
+      changed_services+=("${s}")
+    else
+      echo "[deploy] [${stack_name}] Service ${s}: unchanged (image=${image_ref})"
+    fi
+  done
+
+  if [[ "${force_redeploy}" == "1" || "${force_redeploy}" == "true" || "${force_redeploy}" == "yes" ]]; then
+    echo "[deploy] [${stack_name}] FORCE_REDEPLOY is set. Forcing redeploy even if image digests are unchanged."
+    changed_services=("${services[@]}")
   fi
 
-  new_image_id="$(docker image inspect -f '{{.Id}}' "${image_ref}" 2>/dev/null || true)"
-  old_image_id="${running_image_by_service["${s}"]}"
+  printf '%s\n' "${changed_services[@]:-}"
+}
 
-  if [[ -z "${new_image_id}" ]]; then
-    echo "[deploy] WARN: could not inspect pulled image for service=${s} image=${image_ref}" >&2
-    continue
+declare -a stack_names
+declare -a stack_compose_files
+if [[ -n "${portainer_stack_names_csv}" || -n "${compose_files_csv}" ]]; then
+  if [[ -z "${portainer_stack_names_csv}" || -z "${compose_files_csv}" ]]; then
+    echo "[deploy] ERROR: PORTAINER_STACK_NAMES and COMPOSE_FILES must both be set for multi-stack mode" >&2
+    exit 1
   fi
-
-  if [[ -z "${old_image_id}" ]]; then
-    echo "[deploy] Service ${s}: not running -> will start/update (image=${image_ref})"
-    changed_services+=("${s}")
-    continue
+  mapfile -t stack_names < <(split_csv "${portainer_stack_names_csv}")
+  mapfile -t stack_compose_files < <(split_csv "${compose_files_csv}")
+  if (( ${#stack_names[@]} == 0 )); then
+    echo "[deploy] ERROR: no stack names parsed from PORTAINER_STACK_NAMES" >&2
+    exit 1
   fi
-
-  if [[ "${new_image_id}" != "${old_image_id}" ]]; then
-    echo "[deploy] Service ${s}: CHANGED old=${old_image_id} new=${new_image_id} image=${image_ref}"
-    changed_services+=("${s}")
-  else
-    echo "[deploy] Service ${s}: unchanged (image=${image_ref})"
+  if (( ${#stack_names[@]} != ${#stack_compose_files[@]} )); then
+    echo "[deploy] ERROR: PORTAINER_STACK_NAMES count (${#stack_names[@]}) != COMPOSE_FILES count (${#stack_compose_files[@]})" >&2
+    exit 1
   fi
-done
-
-if [[ "${force_redeploy}" == "1" || "${force_redeploy}" == "true" || "${force_redeploy}" == "yes" ]]; then
-  echo "[deploy] FORCE_REDEPLOY is set. Forcing Portainer redeploy even if image digests are unchanged."
-  changed_services=("${services[@]}")
+else
+  stack_names=("${portainer_stack_name}")
+  stack_compose_files=("${compose_file}")
 fi
 
-if (( ${#changed_services[@]} == 0 )); then
-  echo "[deploy] No services changed. Skipping redeploy to minimize downtime."
+echo "[deploy] stack_count=${#stack_names[@]}"
+
+redeployed_any=0
+would_redeploy_any=0
+for i in "${!stack_names[@]}"; do
+  stack_name="${stack_names[$i]}"
+  compose_path="${stack_compose_files[$i]}"
+
+  if [[ ! -f "${compose_path}" ]]; then
+    echo "[deploy] [${stack_name}] ERROR: compose file not found: ${compose_path}" >&2
+    exit 1
+  fi
+
+  export COMPOSE_FILE="${compose_path}"
+
+  mapfile -t changed_services < <(detect_changed_services_for_stack "${stack_name}" "${compose_path}")
+  if (( ${#changed_services[@]} == 0 )); then
+    echo "[deploy] [${stack_name}] No services changed. Skipping redeploy to minimize downtime."
+    continue
+  fi
+
+  would_redeploy_any=1
+
+  echo "[deploy] [${stack_name}] Changes detected. Triggering Portainer-authoritative redeploy."
+  if [[ "${dry_run}" == "1" || "${dry_run}" == "true" || "${dry_run}" == "yes" ]]; then
+    echo "[deploy] [${stack_name}] DRY_RUN is set. Skipping Portainer redeploy."
+  else
+    if ! trigger_portainer_redeploy "${stack_name}"; then
+      exit 1
+    fi
+    redeployed_any=1
+  fi
+
+  echo "[deploy] [${stack_name}] Verifying container digests..."
+  for s in "${changed_services[@]}"; do
+    cid="$(get_container_id "${s}" "${stack_name}" "${compose_path}" || true)"
+    if [[ -z "${cid}" ]]; then
+      echo "[deploy] [${stack_name}] WARN: service ${s} has no container after deploy" >&2
+      continue
+    fi
+    started="$(docker inspect -f '{{.State.StartedAt}}' "${cid}" 2>/dev/null || true)"
+    image="$(docker inspect -f '{{.Config.Image}}' "${cid}" 2>/dev/null || true)"
+    digest="$(docker inspect -f '{{.Image}}' "${cid}" 2>/dev/null || true)"
+    echo "[deploy] [${stack_name}] ${s}: started=${started} image=${image} digest=${digest}"
+  done
+done
+
+if (( would_redeploy_any == 0 )); then
+  echo "[deploy] No changes detected in any stack. Skipping redeploy to minimize downtime."
   exit 0
 fi
 
-echo "[deploy] Changes detected. Triggering Portainer-authoritative redeploy."
-if ! trigger_portainer_redeploy; then
-  exit 1
+if (( redeployed_any == 0 )) && [[ "${dry_run}" == "1" || "${dry_run}" == "true" || "${dry_run}" == "yes" ]]; then
+  echo "[deploy] DRY_RUN complete (changes were detected, but no redeploy was executed)."
+  exit 0
 fi
 
-echo "[deploy] Verifying container digests..."
-for s in "${changed_services[@]}"; do
-  cid="$(get_container_id "${s}" || true)"
-  if [[ -z "${cid}" ]]; then
-    echo "[deploy] WARN: service ${s} has no container after deploy" >&2
-    continue
-  fi
-  started="$(docker inspect -f '{{.State.StartedAt}}' "${cid}" 2>/dev/null || true)"
-  image="$(docker inspect -f '{{.Config.Image}}' "${cid}" 2>/dev/null || true)"
-  digest="$(docker inspect -f '{{.Image}}' "${cid}" 2>/dev/null || true)"
-  echo "[deploy] ${s}: started=${started} image=${image} digest=${digest}"
-done
-
 echo "[deploy] Health check (best-effort)..."
-# If it exists, check it.
 if curl -fsS "${healthcheck_url}" >/dev/null 2>&1; then
   echo "[deploy] jarvis-backend health OK"
 else

--- a/services/assistance/mcp-bundle/Dockerfile
+++ b/services/assistance/mcp-bundle/Dockerfile
@@ -5,6 +5,16 @@ RUN apk add --no-cache python3 py3-pip ca-certificates curl \
     && /opt/venv/bin/pip install --no-cache-dir --upgrade pip \
     && /opt/venv/bin/pip install --no-cache-dir mcp-server-fetch
 
+COPY ./entrypoint.sh /app/entrypoint.sh
+COPY ./proxy.js /app/proxy.js
+COPY ./mcp-config/mcp.json /app/mcp-config/mcp.json
+
 COPY ./mcp-servers/mcp-google-sheets/server.js /app/mcp-servers/mcp-google-sheets/server.js
+COPY ./mcp-servers/mcp-google-tasks/server.js /app/mcp-servers/mcp-google-tasks/server.js
+COPY ./mcp-servers/mcp-google-calendar/server.js /app/mcp-servers/mcp-google-calendar/server.js
+
+RUN chmod +x /app/entrypoint.sh
 
 ENV PATH="/opt/venv/bin:${PATH}"
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/services/assistance/mcp-bundle/entrypoint.sh
+++ b/services/assistance/mcp-bundle/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+mkdir -p /app/mcp-config
+mkdir -p /root/.config/1mcp
+
+if [ ! -f /app/mcp-config/mcp.json ]; then
+  echo "missing_mcp_config" >&2
+  exit 1
+fi
+
+ln -sf /app/mcp-config/mcp.json /root/.config/1mcp/mcp.json
+
+MCP_HTTP_JSON_LIMIT="${ONE_MCP_HTTP_JSON_LIMIT:-5mb}"
+
+# Increase JSON limits in 1mcp HTTP transport (best-effort).
+find /usr/src/app/node_modules -type f -path '*@modelcontextprotocol*' -path '*/server/express.js' 2>/dev/null | while IFS= read -r f; do
+  if [ -z "$f" ]; then
+    continue
+  fi
+  if [ -f "$f" ]; then
+    sed -i "s/express\.json()/express.json({ limit: process.env.ONE_MCP_HTTP_JSON_LIMIT || \"${MCP_HTTP_JSON_LIMIT}\" })/g" "$f" || true
+    sed -i "s/express_1\.default\.json()/express_1.default.json({ limit: process.env.ONE_MCP_HTTP_JSON_LIMIT || \"${MCP_HTTP_JSON_LIMIT}\" })/g" "$f" || true
+  fi
+done
+
+sed -i "s/bodyParser\.json()/bodyParser.json({ limit: process.env.ONE_MCP_HTTP_JSON_LIMIT || \"${MCP_HTTP_JSON_LIMIT}\" })/g" /usr/src/app/transport/http/server.js 2>/dev/null || true
+
+HOST="${ONE_MCP_HOST:-0.0.0.0}"
+PORT="${ONE_MCP_PORT:-${PORT:-3050}}"
+EXTERNAL_URL="${ONE_MCP_EXTERNAL_URL:-https://127.0.0.1:${PORT}}"
+
+exec node /usr/src/app/index.js serve \
+  --transport http \
+  --host "${HOST}" \
+  --port "${PORT}" \
+  --external-url "${EXTERNAL_URL}" \
+  --no-auth \
+  --no-enable-auth \
+  --enable-async-loading \
+  --async-min-servers 0 \
+  --async-timeout 5000

--- a/services/assistance/mcp-bundle/mcp-config/mcp.json
+++ b/services/assistance/mcp-bundle/mcp-config/mcp.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://docs.1mcp.app/schemas/v1.0.0/mcp-config.json",
+  "mcpServers": {
+    "fetch": {
+      "command": "/opt/venv/bin/python",
+      "args": ["-m", "mcp_server_fetch"],
+      "tags": ["fetch", "web"],
+      "disabled": false
+    },
+    "server-sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+      "tags": ["thinking"],
+      "disabled": false
+    },
+    "google-tasks": {
+      "command": "node",
+      "args": ["/app/mcp-servers/mcp-google-tasks/server.js"],
+      "env": {
+        "GOOGLE_CLIENT_ID": "${GOOGLE_CLIENT_ID}",
+        "GOOGLE_CLIENT_SECRET": "${GOOGLE_CLIENT_SECRET}",
+        "GOOGLE_TASKS_CLIENT_ID": "${GOOGLE_TASKS_CLIENT_ID}",
+        "GOOGLE_TASKS_CLIENT_SECRET": "${GOOGLE_TASKS_CLIENT_SECRET}",
+        "GOOGLE_TASKS_SCOPES": "${GOOGLE_TASKS_SCOPES}",
+        "GOOGLE_TASKS_TOKEN_PATH": "${GOOGLE_TASKS_TOKEN_PATH}"
+      },
+      "tags": ["google", "tasks"],
+      "disabled": false
+    },
+    "google-sheets": {
+      "command": "node",
+      "args": ["/app/mcp-servers/mcp-google-sheets/server.js"],
+      "env": {
+        "GOOGLE_CLIENT_ID": "${GOOGLE_CLIENT_ID}",
+        "GOOGLE_CLIENT_SECRET": "${GOOGLE_CLIENT_SECRET}",
+        "GOOGLE_SHEETS_CLIENT_ID": "${GOOGLE_SHEETS_CLIENT_ID}",
+        "GOOGLE_SHEETS_CLIENT_SECRET": "${GOOGLE_SHEETS_CLIENT_SECRET}",
+        "GOOGLE_SHEETS_SCOPES": "${GOOGLE_SHEETS_SCOPES}",
+        "GOOGLE_SHEETS_TOKEN_PATH": "${GOOGLE_SHEETS_TOKEN_PATH}",
+        "GOOGLE_REDIRECT_URI": "${GOOGLE_REDIRECT_URI}",
+        "GOOGLE_SHEETS_REDIRECT_URI": "${GOOGLE_SHEETS_REDIRECT_URI}"
+      },
+      "tags": ["google", "sheets"],
+      "disabled": false
+    },
+    "google-calendar": {
+      "command": "node",
+      "args": ["/app/mcp-servers/mcp-google-calendar/server.js"],
+      "env": {
+        "GOOGLE_CLIENT_ID": "${GOOGLE_CLIENT_ID}",
+        "GOOGLE_CLIENT_SECRET": "${GOOGLE_CLIENT_SECRET}",
+        "GOOGLE_CALENDAR_CLIENT_ID": "${GOOGLE_CALENDAR_CLIENT_ID}",
+        "GOOGLE_CALENDAR_CLIENT_SECRET": "${GOOGLE_CALENDAR_CLIENT_SECRET}",
+        "GOOGLE_CALENDAR_SCOPES": "${GOOGLE_CALENDAR_SCOPES}",
+        "GOOGLE_CALENDAR_TOKEN_PATH": "${GOOGLE_CALENDAR_TOKEN_PATH}",
+        "GOOGLE_CALENDAR_REDIRECT_URI": "${GOOGLE_CALENDAR_REDIRECT_URI}",
+        "GOOGLE_CALENDAR_JARVIS_CALENDAR_NAME": "${GOOGLE_CALENDAR_JARVIS_CALENDAR_NAME}",
+        "GOOGLE_TASKS_CLIENT_ID": "${GOOGLE_TASKS_CLIENT_ID}",
+        "GOOGLE_TASKS_CLIENT_SECRET": "${GOOGLE_TASKS_CLIENT_SECRET}"
+      },
+      "tags": ["google", "calendar"],
+      "disabled": false
+    }
+  }
+}

--- a/services/assistance/mcp-bundle/mcp-servers/mcp-google-calendar/server.js
+++ b/services/assistance/mcp-bundle/mcp-servers/mcp-google-calendar/server.js
@@ -1,0 +1,432 @@
+"use strict";
+
+const APP_NAME = "mcp-google-calendar";
+const APP_VERSION = "0.0.1";
+
+const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3";
+
+function _envOrEmpty(v) {
+  const s = String(v || "").trim();
+  // 1mcp config substitution can leave literal placeholders like "${GOOGLE_CLIENT_ID}".
+  if (/^\$\{[^}]+\}$/.test(s)) return "";
+  return s;
+}
+
+const DEFAULT_REDIRECT_URI = "http://127.0.0.1:53682/oauth2callback";
+const JARVIS_CALENDAR_NAME = String(process.env.GOOGLE_CALENDAR_JARVIS_CALENDAR_NAME || "Jarvis Reminders").trim();
+
+const DEFAULT_SHARED_TOKEN_PATH = "/root/.config/1mcp/google.tokens.json";
+const TOKEN_PATH = (process.env.GOOGLE_CALENDAR_TOKEN_PATH || DEFAULT_SHARED_TOKEN_PATH).trim();
+const CLIENT_ID =
+  _envOrEmpty(process.env.GOOGLE_CALENDAR_CLIENT_ID) ||
+  _envOrEmpty(process.env.GOOGLE_TASKS_CLIENT_ID) ||
+  _envOrEmpty(process.env.GOOGLE_CLIENT_ID);
+const CLIENT_SECRET =
+  _envOrEmpty(process.env.GOOGLE_CALENDAR_CLIENT_SECRET) ||
+  _envOrEmpty(process.env.GOOGLE_TASKS_CLIENT_SECRET) ||
+  _envOrEmpty(process.env.GOOGLE_CLIENT_SECRET);
+const REDIRECT_URI = String(process.env.GOOGLE_CALENDAR_REDIRECT_URI || DEFAULT_REDIRECT_URI).trim();
+const DEFAULT_SCOPES_SHARED = [
+  "https://www.googleapis.com/auth/spreadsheets.readonly",
+  "https://www.googleapis.com/auth/calendar",
+  "https://www.googleapis.com/auth/tasks",
+].join(" ");
+const DEFAULT_SCOPES = TOKEN_PATH === DEFAULT_SHARED_TOKEN_PATH
+  ? DEFAULT_SCOPES_SHARED
+  : "https://www.googleapis.com/auth/calendar";
+const SCOPES = String(process.env.GOOGLE_CALENDAR_SCOPES || DEFAULT_SCOPES)
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function safeJsonParse(s) {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}
+
+let _ioMode = null; // "content-length" | "line"
+
+function write(obj) {
+  const body = JSON.stringify(obj);
+  if (_ioMode === "line") {
+    process.stdout.write(body + "\n");
+    return;
+  }
+  const len = Buffer.byteLength(body, "utf8");
+  process.stdout.write("Content-Length: " + String(len) + "\r\n\r\n" + body);
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function ensureTokenDir() {
+  const dir = path.dirname(TOKEN_PATH);
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function readTokens() {
+  try {
+    if (!fs.existsSync(TOKEN_PATH)) return null;
+    const raw = fs.readFileSync(TOKEN_PATH, "utf-8");
+    const obj = safeJsonParse(raw);
+    if (!obj || typeof obj !== "object") return null;
+    return obj;
+  } catch {
+    return null;
+  }
+}
+
+function writeTokens(tokens) {
+  ensureTokenDir();
+  fs.writeFileSync(TOKEN_PATH, JSON.stringify(tokens, null, 2));
+}
+
+function requireClientId() {
+  if (!CLIENT_ID) {
+    throw new Error("missing_google_calendar_client_id");
+  }
+}
+
+function secondsNow() {
+  return Math.floor(Date.now() / 1000);
+}
+
+async function httpForm(url, formObj) {
+  const body = new URLSearchParams();
+  for (const [k, v] of Object.entries(formObj || {})) {
+    if (v === undefined || v === null) continue;
+    body.set(k, String(v));
+  }
+
+  const r = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      accept: "application/json",
+    },
+    body,
+  });
+
+  const text = await r.text();
+  const obj = safeJsonParse(text) || { raw: text };
+  if (!r.ok) {
+    const e = new Error("http_error");
+    e.details = { url, status: r.status, body: obj };
+    throw e;
+  }
+  return obj;
+}
+
+async function refreshAccessToken(refreshToken) {
+  requireClientId();
+  const payload = {
+    client_id: CLIENT_ID,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    redirect_uri: REDIRECT_URI,
+  };
+  if (CLIENT_SECRET) payload.client_secret = CLIENT_SECRET;
+
+  const res = await httpForm(GOOGLE_TOKEN_URL, payload);
+  const access_token = res.access_token;
+  const expires_in = Number(res.expires_in || 0);
+  if (!access_token || !expires_in) {
+    const e = new Error("invalid_refresh_response");
+    e.details = res;
+    throw e;
+  }
+  return {
+    access_token,
+    expires_at: secondsNow() + Math.max(30, expires_in - 10),
+  };
+}
+
+async function getValidAccessToken() {
+  const tokens = readTokens();
+  if (!tokens || typeof tokens !== "object") {
+    const e = new Error("auth_required");
+    e.details = {
+      token_path: TOKEN_PATH,
+      hint: "Run: node /app/mcp-servers/mcp-google-calendar/server.js auth",
+    };
+    throw e;
+  }
+
+  const access = typeof tokens.access_token === "string" ? tokens.access_token : "";
+  const expires_at = Number(tokens.expires_at || 0);
+  const refresh = typeof tokens.refresh_token === "string" ? tokens.refresh_token : "";
+
+  if (access && expires_at && expires_at > secondsNow() + 30) {
+    return access;
+  }
+
+  if (!refresh) {
+    const e = new Error("auth_required");
+    e.details = {
+      token_path: TOKEN_PATH,
+      reason: "missing_refresh_token",
+      hint: "Re-run auth: node /app/mcp-servers/mcp-google-calendar/server.js auth",
+    };
+    throw e;
+  }
+
+  const refreshed = await refreshAccessToken(refresh);
+  const merged = { ...tokens, ...refreshed };
+  writeTokens(merged);
+  return merged.access_token;
+}
+
+async function calendarGet(pathname, query) {
+  const token = await getValidAccessToken();
+  const url = new URL(GOOGLE_CALENDAR_API_BASE + pathname);
+  for (const [k, v] of Object.entries(query || {})) {
+    if (v === undefined || v === null) continue;
+    url.searchParams.set(k, String(v));
+  }
+
+  const r = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      authorization: "Bearer " + String(token),
+      accept: "application/json",
+    },
+  });
+
+  const text = await r.text();
+  const obj = safeJsonParse(text) || { raw: text };
+  if (!r.ok) {
+    const e = new Error("google_api_error");
+    e.details = { status: r.status, body: obj };
+    throw e;
+  }
+  return obj;
+}
+
+async function ensureJarvisCalendarId() {
+  const list = await calendarGet("/users/me/calendarList", { maxResults: 250 });
+  const items = Array.isArray(list.items) ? list.items : [];
+  const found = items.find((c) => String(c.summary || "").trim() === JARVIS_CALENDAR_NAME);
+  if (found && found.id) return String(found.id);
+  // If not found, fall back to primary.
+  const primary = items.find((c) => c.primary) || items.find((c) => String(c.id || "") === "primary");
+  if (primary && primary.id) return String(primary.id);
+  return "primary";
+}
+
+const TOOLS = [
+  {
+    name: "google_calendar_ping",
+    description: "Minimal connectivity test for the Google Calendar MCP server.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        message: { type: "string", description: "Optional message to echo." },
+      },
+    },
+  },
+  {
+    name: "google_calendar_auth_status",
+    description: "Check OAuth token status for Google Calendar (single-account).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        include_raw_tokens: {
+          type: "boolean",
+          description: "If true, include raw token JSON in the response (not recommended).",
+        },
+      },
+    },
+  },
+];
+
+async function handleRpc(msg) {
+  const id = msg && msg.id;
+  const method = msg && msg.method;
+  const params = msg && msg.params;
+
+  const hasId = msg && Object.prototype.hasOwnProperty.call(msg, "id");
+  if (!hasId) return null;
+
+  if (method === "initialize") {
+    const requestedPv = params && params.protocolVersion;
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        protocolVersion: typeof requestedPv === "string" && requestedPv ? requestedPv : "2024-11-05",
+        capabilities: { tools: {}, resources: {}, prompts: {} },
+        serverInfo: { name: APP_NAME, version: APP_VERSION },
+      },
+    };
+  }
+
+  if (method === "tools/list") {
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: { tools: TOOLS },
+    };
+  }
+
+  if (method === "tools/call") {
+    const name = params && params.name;
+    const args = (params && params.arguments) || {};
+
+    if (name === "google_calendar_ping") {
+      const message = typeof args.message === "string" ? args.message : "pong";
+      const calendar_id = await ensureJarvisCalendarId();
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          content: [{ type: "text", text: JSON.stringify({ ok: true, message, server: APP_NAME, version: APP_VERSION, now: nowIso(), calendar_id }) }],
+        },
+      };
+    }
+
+    if (name === "google_calendar_auth_status") {
+      const includeRaw = Boolean(args.include_raw_tokens);
+      const tokens = readTokens();
+      const now = secondsNow();
+      const access_token = tokens && typeof tokens.access_token === "string" ? tokens.access_token : null;
+      const refresh_token = tokens && typeof tokens.refresh_token === "string" ? tokens.refresh_token : null;
+      const expires_at = tokens && tokens.expires_at ? Number(tokens.expires_at) : null;
+      const scope = tokens && typeof tokens.scope === "string" ? tokens.scope : SCOPES.join(" ");
+
+      const out = {
+        ok: true,
+        token_path: TOKEN_PATH,
+        has_token_file: Boolean(tokens),
+        has_access_token: Boolean(access_token),
+        has_refresh_token: Boolean(refresh_token),
+        expires_at: expires_at,
+        expires_in_seconds: expires_at ? Math.max(0, expires_at - now) : null,
+        is_access_token_valid: expires_at ? expires_at > now + 30 : false,
+        scopes: String(scope)
+          .split(/\s+/)
+          .map((s) => s.trim())
+          .filter(Boolean),
+        client_id_present: Boolean(CLIENT_ID),
+        calendar_name: JARVIS_CALENDAR_NAME,
+      };
+
+      if (includeRaw) out.raw_tokens = tokens;
+
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: { content: [{ type: "text", text: JSON.stringify(out) }] },
+      };
+    }
+
+    return {
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32601, message: "tool_not_found" },
+    };
+  }
+
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: { code: -32601, message: "method_not_found" },
+  };
+}
+
+let buf = Buffer.alloc(0);
+let lineBuf = "";
+
+function parseNextFrame(buffer) {
+  let headerEnd = buffer.indexOf(Buffer.from("\r\n\r\n"));
+  let headerSepLen = 4;
+  if (headerEnd < 0) {
+    headerEnd = buffer.indexOf(Buffer.from("\n\n"));
+    headerSepLen = 2;
+  }
+  if (headerEnd < 0) return null;
+
+  const headerText = buffer.slice(0, headerEnd).toString("utf8");
+  const headers = headerText.split(/\r?\n/);
+  let contentLength = null;
+  for (const h of headers) {
+    const m = /^content-length\s*:\s*(\d+)\s*$/i.exec(h);
+    if (m) {
+      contentLength = Number(m[1]);
+      break;
+    }
+  }
+  if (!contentLength || !Number.isFinite(contentLength) || contentLength <= 0) {
+    return null;
+  }
+
+  const bodyStart = headerEnd + headerSepLen;
+  if (buffer.length < bodyStart + contentLength) return null;
+
+  const bodyBuf = buffer.slice(bodyStart, bodyStart + contentLength);
+  const rest = buffer.slice(bodyStart + contentLength);
+  return { body: bodyBuf.toString("utf8"), rest };
+}
+
+async function handleMessage(msg) {
+  try {
+    const res = await handleRpc(msg);
+    if (res) write(res);
+  } catch (e) {
+    write({
+      jsonrpc: "2.0",
+      id: msg && Object.prototype.hasOwnProperty.call(msg, "id") ? msg.id : null,
+      error: { code: -32603, message: "Internal error", data: { error: String(e && e.message ? e.message : e) } },
+    });
+  }
+}
+
+async function main() {
+  process.stdin.on("data", async (chunk) => {
+    const b = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), "utf8");
+    buf = Buffer.concat([buf, b]);
+    lineBuf += b.toString("utf8");
+
+    while (true) {
+      const frame = parseNextFrame(buf);
+      if (!frame) break;
+      _ioMode = _ioMode || "content-length";
+      buf = frame.rest;
+      const msg = safeJsonParse(frame.body);
+      if (!msg) continue;
+      await handleMessage(msg);
+    }
+
+    while (true) {
+      const idx = lineBuf.indexOf("\n");
+      if (idx < 0) break;
+      const line = lineBuf.slice(0, idx).trim();
+      lineBuf = lineBuf.slice(idx + 1);
+      if (!line) continue;
+      const msg = safeJsonParse(line);
+      if (!msg) continue;
+      _ioMode = _ioMode || "line";
+      await handleMessage(msg);
+    }
+  });
+
+  process.stdin.on("end", () => process.exit(0));
+}
+
+main().catch((e) => {
+  try {
+    if (e && e.details) {
+      process.stderr.write("mcp-google-calendar error details: " + JSON.stringify(e.details) + "\n");
+    }
+  } catch {}
+  process.stderr.write("mcp-google-calendar startup error: " + String(e && e.message ? e.message : e) + "\n");
+  process.exit(1);
+});

--- a/services/assistance/mcp-bundle/mcp-servers/mcp-google-tasks/server.js
+++ b/services/assistance/mcp-bundle/mcp-servers/mcp-google-tasks/server.js
@@ -1,0 +1,513 @@
+"use strict";
+
+const APP_NAME = "mcp-google-tasks";
+const APP_VERSION = "0.0.1";
+
+const GOOGLE_DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_TASKS_API_BASE = "https://tasks.googleapis.com/tasks/v1";
+
+function _envOrEmpty(v) {
+  const s = String(v || "").trim();
+  // 1mcp config substitution can leave literal placeholders like "${GOOGLE_CLIENT_ID}".
+  if (/^\$\{[^}]+\}$/.test(s)) return "";
+  return s;
+}
+
+const DEFAULT_SHARED_TOKEN_PATH = "/root/.config/1mcp/google.tokens.json";
+const TOKEN_PATH = (process.env.GOOGLE_TASKS_TOKEN_PATH || DEFAULT_SHARED_TOKEN_PATH).trim();
+const CLIENT_ID = _envOrEmpty(process.env.GOOGLE_TASKS_CLIENT_ID) || _envOrEmpty(process.env.GOOGLE_CLIENT_ID);
+const CLIENT_SECRET = _envOrEmpty(process.env.GOOGLE_TASKS_CLIENT_SECRET) || _envOrEmpty(process.env.GOOGLE_CLIENT_SECRET);
+const DEFAULT_SCOPES_SHARED = [
+  "https://www.googleapis.com/auth/spreadsheets.readonly",
+  "https://www.googleapis.com/auth/calendar",
+  "https://www.googleapis.com/auth/tasks",
+].join(" ");
+const DEFAULT_SCOPES = TOKEN_PATH === DEFAULT_SHARED_TOKEN_PATH
+  ? DEFAULT_SCOPES_SHARED
+  : "https://www.googleapis.com/auth/tasks";
+const SCOPES = String(process.env.GOOGLE_TASKS_SCOPES || DEFAULT_SCOPES)
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function safeJsonParse(s) {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}
+
+function write(obj) {
+  const body = JSON.stringify(obj);
+  const len = Buffer.byteLength(body, "utf8");
+  process.stdout.write(`Content-Length: ${len}\r\n\r\n${body}`);
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function ensureTokenDir() {
+  const dir = path.dirname(TOKEN_PATH);
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function readTokens() {
+  try {
+    if (!fs.existsSync(TOKEN_PATH)) return null;
+    const raw = fs.readFileSync(TOKEN_PATH, "utf-8");
+    const obj = safeJsonParse(raw);
+    if (!obj || typeof obj !== "object") return null;
+    return obj;
+  } catch {
+    return null;
+  }
+}
+
+function writeTokens(tokens) {
+  ensureTokenDir();
+  fs.writeFileSync(TOKEN_PATH, JSON.stringify(tokens, null, 2));
+}
+
+function requireClientId() {
+  if (!CLIENT_ID) {
+    throw new Error("missing_google_tasks_client_id");
+  }
+}
+
+function secondsNow() {
+  return Math.floor(Date.now() / 1000);
+}
+
+async function httpForm(url, formObj) {
+  const body = new URLSearchParams();
+  for (const [k, v] of Object.entries(formObj || {})) {
+    if (v === undefined || v === null) continue;
+    body.set(k, String(v));
+  }
+
+  const r = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      accept: "application/json",
+    },
+    body,
+  });
+
+  const text = await r.text();
+  const obj = safeJsonParse(text) || { raw: text };
+  if (!r.ok) {
+    const e = new Error("http_error");
+    e.details = { url, status: r.status, body: obj };
+    throw e;
+  }
+  return obj;
+}
+
+async function refreshAccessToken(refreshToken) {
+  requireClientId();
+  const payload = {
+    client_id: CLIENT_ID,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  };
+  if (CLIENT_SECRET) payload.client_secret = CLIENT_SECRET;
+
+  const res = await httpForm(GOOGLE_TOKEN_URL, payload);
+  const access_token = res.access_token;
+  const expires_in = Number(res.expires_in || 0);
+  if (!access_token || !expires_in) {
+    const e = new Error("invalid_refresh_response");
+    e.details = res;
+    throw e;
+  }
+  return {
+    access_token,
+    expires_at: secondsNow() + Math.max(30, expires_in - 10),
+  };
+}
+
+async function getValidAccessToken() {
+  const tokens = readTokens();
+  if (!tokens || typeof tokens !== "object") {
+    const e = new Error("auth_required");
+    e.details = {
+      token_path: TOKEN_PATH,
+      hint: "Run: node /app/mcp-servers/mcp-google-tasks/server.js auth",
+    };
+    throw e;
+  }
+
+  const access = typeof tokens.access_token === "string" ? tokens.access_token : "";
+  const expires_at = Number(tokens.expires_at || 0);
+  const refresh = typeof tokens.refresh_token === "string" ? tokens.refresh_token : "";
+
+  if (access && expires_at && expires_at > secondsNow() + 30) {
+    return access;
+  }
+
+  if (!refresh) {
+    const e = new Error("auth_required");
+    e.details = {
+      token_path: TOKEN_PATH,
+      reason: "missing_refresh_token",
+      hint: "Re-run auth: node /app/mcp-servers/mcp-google-tasks/server.js auth",
+    };
+    throw e;
+  }
+
+  const refreshed = await refreshAccessToken(refresh);
+  const merged = { ...tokens, ...refreshed };
+  writeTokens(merged);
+  return merged.access_token;
+}
+
+async function googleTasksGet(pathname, query) {
+  const token = await getValidAccessToken();
+  const url = new URL(GOOGLE_TASKS_API_BASE + pathname);
+  for (const [k, v] of Object.entries(query || {})) {
+    if (v === undefined || v === null) continue;
+    url.searchParams.set(k, String(v));
+  }
+
+  const r = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      authorization: "Bearer " + String(token),
+      accept: "application/json",
+    },
+  });
+
+  const text = await r.text();
+  const obj = safeJsonParse(text) || { raw: text };
+  if (!r.ok) {
+    const e = new Error("google_api_error");
+    e.details = { status: r.status, body: obj };
+    throw e;
+  }
+  return obj;
+}
+
+async function runDeviceFlowAuth() {
+  requireClientId();
+  ensureTokenDir();
+
+  const deviceRes = await httpForm(GOOGLE_DEVICE_CODE_URL, {
+    client_id: CLIENT_ID,
+    scope: SCOPES.join(" "),
+  });
+
+  const device_code = String(deviceRes.device_code || "").trim();
+  const user_code = String(deviceRes.user_code || "").trim();
+  const verification_url = String(deviceRes.verification_url || deviceRes.verification_uri || "").trim();
+  const interval = Number(deviceRes.interval || 5);
+  const expires_in = Number(deviceRes.expires_in || 0);
+
+  if (!device_code || !user_code || !verification_url) {
+    const e = new Error("invalid_device_code_response");
+    e.details = deviceRes;
+    throw e;
+  }
+
+  process.stderr.write("\n== Google Tasks OAuth (Device Code) ==\n");
+  process.stderr.write("Open: " + verification_url + "\n");
+  process.stderr.write("Enter code: " + user_code + "\n\n");
+
+  const start = Date.now();
+  const timeoutMs = expires_in ? expires_in * 1000 : 10 * 60 * 1000;
+
+  // Poll token endpoint.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (Date.now() - start > timeoutMs) throw new Error("auth_timeout");
+
+    try {
+      const tok = await httpForm(GOOGLE_TOKEN_URL, {
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET || undefined,
+        device_code,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      });
+
+      const access_token = tok.access_token;
+      const refresh_token = tok.refresh_token;
+      const expires_in2 = Number(tok.expires_in || 0);
+
+      if (!access_token) {
+        const e = new Error("token_missing_access_token");
+        e.details = tok;
+        throw e;
+      }
+
+      const tokens = {
+        access_token,
+        refresh_token,
+        token_type: tok.token_type,
+        scope: tok.scope,
+        expires_at: expires_in2 ? secondsNow() + expires_in2 : null,
+        updated_at: nowIso(),
+      };
+
+      writeTokens(tokens);
+      process.stderr.write("Saved tokens to " + TOKEN_PATH + "\n");
+      return tokens;
+    } catch (e) {
+      const code = e && e.details && e.details.body && e.details.body.error ? String(e.details.body.error) : "";
+      if (code === "authorization_pending" || code === "slow_down") {
+        await new Promise((r) => setTimeout(r, Math.max(1000, interval * 1000)));
+        continue;
+      }
+      throw e;
+    }
+  }
+}
+
+const TOOLS = [
+  {
+    name: "google_tasks_ping",
+    description: "Minimal connectivity test for the Google Tasks MCP server.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        message: { type: "string", description: "Optional message to echo." },
+      },
+    },
+  },
+  {
+    name: "google_tasks_auth_status",
+    description: "Check OAuth token status for Google Tasks (single-account).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        include_raw_tokens: {
+          type: "boolean",
+          description: "If true, include raw token JSON in the response (not recommended).",
+        },
+      },
+    },
+  },
+  {
+    name: "google_tasks_list_tasklists",
+    description: "List the user's Google Tasklists (requires OAuth tokens).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        max_results: { type: "integer", description: "Max results (1-100)." },
+        page_token: { type: "string", description: "Page token from a previous call." },
+      },
+    },
+  },
+];
+
+async function handleRpc(msg) {
+  const id = msg && msg.id;
+  const method = msg && msg.method;
+  const params = msg && msg.params;
+
+  const hasId = msg && Object.prototype.hasOwnProperty.call(msg, "id");
+  if (!hasId) return null;
+
+  if (method === "initialize") {
+    const requestedPv = params && params.protocolVersion;
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        protocolVersion: typeof requestedPv === "string" && requestedPv ? requestedPv : "2024-11-05",
+        capabilities: { tools: {}, resources: {}, prompts: {} },
+        serverInfo: { name: APP_NAME, version: APP_VERSION },
+      },
+    };
+  }
+
+  if (method === "tools/list") {
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: { tools: TOOLS },
+    };
+  }
+
+  if (method === "tools/call") {
+    const name = params && params.name;
+    const args = (params && params.arguments) || {};
+
+    if (name === "google_tasks_ping") {
+      const message = typeof args.message === "string" ? args.message : "pong";
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          content: [{ type: "text", text: JSON.stringify({ ok: true, message, server: APP_NAME, version: APP_VERSION, now: nowIso() }) }],
+        },
+      };
+    }
+
+    if (name === "google_tasks_auth_status") {
+      const includeRaw = Boolean(args.include_raw_tokens);
+      const tokens = readTokens();
+      const now = secondsNow();
+      const access_token = tokens && typeof tokens.access_token === "string" ? tokens.access_token : null;
+      const refresh_token = tokens && typeof tokens.refresh_token === "string" ? tokens.refresh_token : null;
+      const expires_at = tokens && tokens.expires_at ? Number(tokens.expires_at) : null;
+      const scope = tokens && typeof tokens.scope === "string" ? tokens.scope : SCOPES.join(" ");
+
+      const out = {
+        ok: true,
+        token_path: TOKEN_PATH,
+        has_token_file: Boolean(tokens),
+        has_access_token: Boolean(access_token),
+        has_refresh_token: Boolean(refresh_token),
+        expires_at: expires_at,
+        expires_in_seconds: expires_at ? Math.max(0, expires_at - now) : null,
+        is_access_token_valid: expires_at ? expires_at > now + 30 : false,
+        scopes: String(scope)
+          .split(/\s+/)
+          .map((s) => s.trim())
+          .filter(Boolean),
+        client_id_present: Boolean(CLIENT_ID),
+        auth_hint: "Run: node /app/mcp-servers/mcp-google-tasks/server.js auth",
+      };
+
+      if (includeRaw) out.raw_tokens = tokens;
+
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: { content: [{ type: "text", text: JSON.stringify(out) }] },
+      };
+    }
+
+    if (name === "google_tasks_list_tasklists") {
+      const max_results_raw = args.max_results;
+      const page_token_raw = args.page_token;
+      const maxResults =
+        typeof max_results_raw === "number" && Number.isFinite(max_results_raw)
+          ? Math.max(1, Math.min(100, Math.floor(max_results_raw)))
+          : undefined;
+      const pageToken = typeof page_token_raw === "string" && page_token_raw.trim() ? page_token_raw.trim() : undefined;
+
+      const data = await googleTasksGet("/users/@me/lists", {
+        maxResults,
+        pageToken,
+      });
+
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: { content: [{ type: "text", text: JSON.stringify({ ok: true, data }) }] },
+      };
+    }
+
+    return {
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32601, message: "tool_not_found" },
+    };
+  }
+
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: { code: -32601, message: "method_not_found" },
+  };
+}
+
+function parseNextFrame(buffer) {
+  let headerEnd = buffer.indexOf(Buffer.from("\r\n\r\n"));
+  let headerSepLen = 4;
+  if (headerEnd < 0) {
+    headerEnd = buffer.indexOf(Buffer.from("\n\n"));
+    headerSepLen = 2;
+  }
+  if (headerEnd < 0) return null;
+
+  const headerText = buffer.slice(0, headerEnd).toString("utf8");
+  const headers = headerText.split(/\r?\n/);
+  let contentLength = null;
+  for (const h of headers) {
+    const m = /^content-length\s*:\s*(\d+)\s*$/i.exec(h);
+    if (m) {
+      contentLength = Number(m[1]);
+      break;
+    }
+  }
+  if (!contentLength || !Number.isFinite(contentLength) || contentLength <= 0) {
+    return null;
+  }
+
+  const bodyStart = headerEnd + headerSepLen;
+  if (buffer.length < bodyStart + contentLength) return null;
+
+  const bodyBuf = buffer.slice(bodyStart, bodyStart + contentLength);
+  const rest = buffer.slice(bodyStart + contentLength);
+  return { body: bodyBuf.toString("utf8"), rest };
+}
+
+async function handleMessage(msg) {
+  try {
+    const res = await handleRpc(msg);
+    if (res) write(res);
+  } catch (e) {
+    write({
+      jsonrpc: "2.0",
+      id: msg && Object.prototype.hasOwnProperty.call(msg, "id") ? msg.id : null,
+      error: { code: -32603, message: "Internal error", data: { error: String(e && e.message ? e.message : e) } },
+    });
+  }
+}
+
+let buf = Buffer.alloc(0);
+let lineBuf = "";
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("auth")) {
+    await runDeviceFlowAuth();
+    process.exit(0);
+  }
+
+  process.stdin.on("data", async (chunk) => {
+    const b = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), "utf8");
+    buf = Buffer.concat([buf, b]);
+    lineBuf += b.toString("utf8");
+
+    while (true) {
+      const frame = parseNextFrame(buf);
+      if (!frame) break;
+      buf = frame.rest;
+      const msg = safeJsonParse(frame.body);
+      if (!msg) continue;
+      await handleMessage(msg);
+    }
+
+    while (true) {
+      const idx = lineBuf.indexOf("\n");
+      if (idx < 0) break;
+      const line = lineBuf.slice(0, idx).trim();
+      lineBuf = lineBuf.slice(idx + 1);
+      if (!line) continue;
+      const msg = safeJsonParse(line);
+      if (!msg) continue;
+      await handleMessage(msg);
+    }
+  });
+
+  process.stdin.on("end", () => process.exit(0));
+}
+
+main().catch((e) => {
+  try {
+    if (e && e.details) {
+      process.stderr.write("mcp-google-tasks error details: " + JSON.stringify(e.details) + "\n");
+    }
+  } catch {}
+  process.stderr.write("mcp-google-tasks startup error: " + String(e && e.message ? e.message : e) + "\n");
+  process.exit(1);
+});

--- a/services/assistance/mcp-bundle/proxy.js
+++ b/services/assistance/mcp-bundle/proxy.js
@@ -1,0 +1,169 @@
+const http = require("http");
+const { spawn } = require("child_process");
+
+const PROXY_PORT = Number(process.env.ONE_MCP_PORT || process.env.PORT || 3050);
+const PROXY_HOST = String(process.env.ONE_MCP_HOST || "0.0.0.0");
+const UPSTREAM_PORT = Number(process.env.ONE_MCP_UPSTREAM_PORT || 3052);
+const UPSTREAM_HOST = "127.0.0.1";
+const JSON_LIMIT = String(process.env.ONE_MCP_PROXY_JSON_LIMIT || "5mb");
+
+function parseLimitToBytes(limit) {
+  const s = String(limit || "").trim().toLowerCase();
+  const m = /^(\d+)(b|kb|mb)?$/.exec(s);
+  if (!m) return 5 * 1024 * 1024;
+  const n = Number(m[1]);
+  const unit = m[2] || "b";
+  if (!Number.isFinite(n) || n <= 0) return 5 * 1024 * 1024;
+  if (unit === "kb") return n * 1024;
+  if (unit === "mb") return n * 1024 * 1024;
+  return n;
+}
+
+const JSON_LIMIT_BYTES = parseLimitToBytes(JSON_LIMIT);
+
+function sendJson(res, status, obj) {
+  const txt = JSON.stringify(obj);
+  res.statusCode = status;
+  res.setHeader("content-type", "application/json");
+  res.end(txt);
+}
+
+function startUpstream() {
+  const env = {
+    ...process.env,
+    // 1mcp (base image) commonly uses PORT; the legacy compose override used ONE_MCP_PORT.
+    // Set both to ensure the upstream actually binds to the expected port.
+    PORT: String(UPSTREAM_PORT),
+    ONE_MCP_PORT: String(UPSTREAM_PORT),
+    // Upstream should only be reachable from within the container.
+    ONE_MCP_HOST: "127.0.0.1",
+  };
+  const child = spawn(
+    "node",
+    [
+      "/usr/src/app/index.js",
+      "serve",
+      "--transport",
+      "http",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(UPSTREAM_PORT),
+    ],
+    { env, stdio: "inherit" }
+  );
+  child.on("exit", (code) => {
+    process.stderr.write(`upstream 1mcp exited code=${code}\n`);
+    process.exit(code || 1);
+  });
+  return child;
+}
+
+async function waitHealthy(timeoutMs = 20000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const r = await fetch(`http://${UPSTREAM_HOST}:${UPSTREAM_PORT}/health`);
+      if (r.ok) return true;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return false;
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks = [];
+    req.on("data", (c) => {
+      const b = Buffer.isBuffer(c) ? c : Buffer.from(String(c), "utf8");
+      size += b.length;
+      if (size > JSON_LIMIT_BYTES) {
+        const err = new Error("request entity too large");
+        err.code = "entity.too.large";
+        reject(err);
+        req.destroy();
+        return;
+      }
+      chunks.push(b);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+async function main() {
+  startUpstream();
+  const ok = await waitHealthy();
+  if (!ok) {
+    process.stderr.write("upstream healthcheck failed\n");
+  }
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const u = new URL(req.url || "/", "http://127.0.0.1");
+
+      if (req.method === "GET" && u.pathname === "/health") {
+        const r = await fetch(`http://${UPSTREAM_HOST}:${UPSTREAM_PORT}/health`);
+        const txt = await r.text();
+        res.statusCode = r.status;
+        const ct = r.headers.get("content-type");
+        if (ct) res.setHeader("content-type", ct);
+        res.end(txt);
+        return;
+      }
+
+      if (req.method === "POST" && u.pathname === "/mcp") {
+        const bodyBuf = await readBody(req);
+        let parsed = {};
+        if (bodyBuf.length) {
+          try {
+            parsed = JSON.parse(bodyBuf.toString("utf8"));
+          } catch {
+            sendJson(res, 400, { ok: false, error: "invalid_json" });
+            return;
+          }
+        }
+
+        const url = `http://${UPSTREAM_HOST}:${UPSTREAM_PORT}/mcp${u.search || ""}`;
+        const r = await fetch(url, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            accept: String(req.headers.accept || "application/json, text/event-stream"),
+            "mcp-session-id": String(req.headers["mcp-session-id"] || ""),
+          },
+          body: JSON.stringify(parsed || {}),
+        });
+
+        res.statusCode = r.status;
+        const ct = r.headers.get("content-type");
+        if (ct) res.setHeader("content-type", ct);
+        const sid = r.headers.get("mcp-session-id");
+        if (sid) res.setHeader("mcp-session-id", sid);
+        const out = Buffer.from(await r.arrayBuffer());
+        res.end(out);
+        return;
+      }
+
+      sendJson(res, 404, { ok: false, error: "not_found" });
+    } catch (e) {
+      if (e && e.code === "entity.too.large") {
+        sendJson(res, 413, { ok: false, error: "entity.too.large", limit: JSON_LIMIT_BYTES });
+        return;
+      }
+      sendJson(res, 502, { ok: false, error: String(e && e.message ? e.message : e) });
+    }
+  });
+
+  server.listen(PROXY_PORT, PROXY_HOST, () => {
+    process.stdout.write(
+      `mcp proxy listening on http://${PROXY_HOST}:${PROXY_PORT} (json limit ${JSON_LIMIT}), upstream :${UPSTREAM_PORT}\n`
+    );
+  });
+}
+
+main().catch((e) => {
+  process.stderr.write(`proxy startup error: ${String(e && e.message ? e.message : e)}\n`);
+  process.exit(1);
+});

--- a/stacks/idc1-assistance-core/docker-compose.yml
+++ b/stacks/idc1-assistance-core/docker-compose.yml
@@ -1,0 +1,118 @@
+version: "3.9"
+
+x-default-service: &default-service
+  restart: unless-stopped
+  env_file:
+    - ../idc1-assistance/.env.example
+  networks:
+    - idc1-stack-net
+  logging:
+    driver: "json-file"
+    options:
+      max-size: "10m"
+      max-file: "3"
+
+services:
+  jarvis-backend:
+    <<: *default-service
+    image: ghcr.io/tonezzz/chaba/jarvis-backend:idc1-assistance
+    ports:
+      - "127.0.0.1:18018:8018"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      PORT: 8018
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      GEMINI_LIVE_MODEL: ${GEMINI_LIVE_MODEL:-gemini-2.5-flash-native-audio-preview-12-2025}
+      JARVIS_PUBLIC_BASE_URL: ${JARVIS_PUBLIC_BASE_URL:-https://assistance.idc1.surf-thailand.com}
+      JARVIS_VERIFY_FRONTEND_BASE_URL: ${JARVIS_VERIFY_FRONTEND_BASE_URL:-}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      JARVIS_RECENT_DIALOG_TTL_SECONDS: ${JARVIS_RECENT_DIALOG_TTL_SECONDS:-86400}
+      JARVIS_RECENT_DIALOG_MAX_TURNS: ${JARVIS_RECENT_DIALOG_MAX_TURNS:-60}
+      JARVIS_RECENT_DIALOG_MAX_CHARS: ${JARVIS_RECENT_DIALOG_MAX_CHARS:-4000}
+      JARVIS_FEATURE_MEMO_ENABLED: "true"
+      JARVIS_FEATURE_MEMORY_ENABLED: "false"
+      JARVIS_FEATURE_KNOWLEDGE_ENABLED: "false"
+      GITHUB_PERSONAL_TOKEN_RO: ${GITHUB_PERSONAL_TOKEN_RO:-}
+      GITHUB_PERSONAL_TOKEN_RW: ${GITHUB_PERSONAL_TOKEN_RW:-}
+      CHABA_SYSTEM_SPREADSHEET_ID: ${CHABA_SYSTEM_SPREADSHEET_ID:-}
+      CHABA_SYSTEM_SHEET_NAME: ${CHABA_SYSTEM_SHEET_NAME:-}
+      JARVIS_SHEETS_LOGS_ENABLED: ${JARVIS_SHEETS_LOGS_ENABLED:-true}
+      JARVIS_SHEETS_LOGS_SHEET_NAME: ${JARVIS_SHEETS_LOGS_SHEET_NAME:-logs}
+      PORTAINER_URL: ${PORTAINER_URL:-http://portainer:9000}
+      PORTAINER_TOKEN: ${PORTAINER_TOKEN:-}
+      PORTAINER_ENDPOINT_ID: ${PORTAINER_ENDPOINT_ID:-2}
+      PORTAINER_STACK_NAME: ${PORTAINER_STACK_NAME:-idc1-assistance}
+      JARVIS_SESSION_DB: ${JARVIS_SESSION_DB:-/data/jarvis_sessions.sqlite}
+      JARVIS_IMAGEN_ASSETS_DIR: ${JARVIS_IMAGEN_ASSETS_DIR:-/app/imagen_assets}
+      JARVIS_CARS_DATA_DIR: ${JARVIS_CARS_DATA_DIR:-/app/assistance_data/cars}
+      JARVIS_IMAGEN_MODEL: ${JARVIS_IMAGEN_MODEL:-imagen-4.0-generate-001}
+      JARVIS_IMAGEN_ALLOWED_MODELS: ${JARVIS_IMAGEN_ALLOWED_MODELS:-imagen-4.0-generate-001,imagen-4.0-ultra-generate-001,imagen-4.0-fast-generate-001}
+      JARVIS_IMAGE_MODEL: ${JARVIS_IMAGE_MODEL:-gemini-3.1-flash-image-preview}
+      JARVIS_IMAGE_ALLOWED_MODELS: ${JARVIS_IMAGE_ALLOWED_MODELS:-gemini-3.1-flash-image-preview}
+      WEB_FETCHER_BASE_URL: ${WEB_FETCHER_BASE_URL:-http://web-fetcher:8028}
+      MCP_BASE_URL: ${MCP_BASE_URL:-http://mcp-bundle-assistance:3050}
+      MCP_PLAYWRIGHT_BASE_URL: ${MCP_PLAYWRIGHT_BASE_URL:-http://mcp-playwright:3050}
+      DEEP_RESEARCH_WORKER_BASE_URL: ${DEEP_RESEARCH_WORKER_BASE_URL:-http://deep-research-worker:8030}
+      WEAVIATE_URL: ${WEAVIATE_URL:-http://weaviate:8080}
+    volumes:
+      - jarvis-imagen-assets:${JARVIS_IMAGEN_ASSETS_DIR:-/app/imagen_assets}
+      - jarvis-session-db:/data
+      - ../../services/assistance_data:/app/assistance_data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8018/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - idc1-stack-net
+      - idc1-portainer_default
+
+  jarvis-frontend:
+    <<: *default-service
+    image: ghcr.io/tonezzz/chaba/jarvis-frontend:idc1-assistance
+    ports:
+      - "127.0.0.1:18080:80"
+
+  web-fetcher:
+    <<: *default-service
+    image: ghcr.io/tonezzz/chaba/web-fetcher:idc1-assistance
+    environment:
+      PORT: 8028
+      WEB_FETCH_MAX_BYTES: ${WEB_FETCH_MAX_BYTES:-2000000}
+      WEB_FETCH_MAX_REDIRECTS: ${WEB_FETCH_MAX_REDIRECTS:-5}
+      WEB_FETCH_CONNECT_TIMEOUT_S: ${WEB_FETCH_CONNECT_TIMEOUT_S:-5}
+      WEB_FETCH_READ_TIMEOUT_S: ${WEB_FETCH_READ_TIMEOUT_S:-15}
+      WEB_FETCH_ALLOWED_CONTENT_TYPES: ${WEB_FETCH_ALLOWED_CONTENT_TYPES:-text/html,text/plain,application/json}
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8028/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+networks:
+  idc1-stack-net:
+    driver: bridge
+    external: true
+    name: idc1-stack-net
+
+  idc1-portainer_default:
+    driver: bridge
+    external: true
+    name: idc1-portainer_default
+
+volumes:
+  jarvis-imagen-assets:
+    external: true
+    name: ${JARVIS_IMAGEN_ASSETS_VOLUME_NAME:-idc1-assistance_jarvis-imagen-assets}
+
+  jarvis-session-db:
+    external: true
+    name: ${JARVIS_SESSION_DB_VOLUME_NAME:-idc1-assistance_jarvis-session-db}

--- a/stacks/idc1-assistance-infra/docker-compose.yml
+++ b/stacks/idc1-assistance-infra/docker-compose.yml
@@ -1,0 +1,57 @@
+version: "3.9"
+
+x-default-service: &default-service
+  restart: unless-stopped
+  networks:
+    - idc1-stack-net
+  logging:
+    driver: "json-file"
+    options:
+      max-size: "10m"
+      max-file: "3"
+
+services:
+  redis:
+    <<: *default-service
+    image: redis:7-alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - jarvis-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+
+  weaviate:
+    <<: *default-service
+    image: semitechnologies/weaviate:1.24.10
+    environment:
+      QUERY_DEFAULTS_LIMIT: 50
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "true"
+      PERSISTENCE_DATA_PATH: "/var/lib/weaviate"
+      DEFAULT_VECTORIZER_MODULE: "none"
+      ENABLE_MODULES: ""
+      CLUSTER_HOSTNAME: "node1"
+    volumes:
+      - weaviate-data:/var/lib/weaviate
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/v1/.well-known/ready >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+networks:
+  idc1-stack-net:
+    driver: bridge
+    external: true
+    name: idc1-stack-net
+
+volumes:
+  jarvis-redis-data:
+    external: true
+    name: ${JARVIS_REDIS_DATA_VOLUME_NAME:-idc1-assistance_jarvis-redis-data}
+
+  weaviate-data:
+    external: true
+    name: ${WEAVIATE_DATA_VOLUME_NAME:-idc1-assistance_weaviate-data}

--- a/stacks/idc1-assistance-mcp/docker-compose.yml
+++ b/stacks/idc1-assistance-mcp/docker-compose.yml
@@ -1,0 +1,413 @@
+version: "3.9"
+
+x-default-service: &default-service
+  restart: unless-stopped
+  env_file:
+    - ../idc1-assistance/.env.example
+  networks:
+    - idc1-stack-net
+  logging:
+    driver: "json-file"
+    options:
+      max-size: "10m"
+      max-file: "3"
+
+services:
+  mcp-bundle:
+    <<: *default-service
+    image: ghcr.io/tonezzz/chaba/mcp-bundle:idc1-assistance
+    ports:
+      - "127.0.0.1:3051:3050"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      ONE_MCP_HOST: 0.0.0.0
+      ONE_MCP_PORT: 3050
+      ONE_MCP_EXTERNAL_URL: ${ONE_MCP_EXTERNAL_URL:-https://127.0.0.1:3051}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI:-}
+      GOOGLE_SHEETS_REDIRECT_URI: ${GOOGLE_SHEETS_REDIRECT_URI:-}
+      GOOGLE_TASKS_TOKEN_PATH: ${GOOGLE_SHARED_TOKEN_PATH:-/root/.config/1mcp/google.tokens.json}
+      GOOGLE_SHEETS_TOKEN_PATH: ${GOOGLE_SHARED_TOKEN_PATH:-/root/.config/1mcp/google.tokens.json}
+      GOOGLE_CALENDAR_TOKEN_PATH: ${GOOGLE_SHARED_TOKEN_PATH:-/root/.config/1mcp/google.tokens.json}
+      GOOGLE_TASKS_SCOPES: ${GOOGLE_SHARED_SCOPES:-https://www.googleapis.com/auth/tasks,https://www.googleapis.com/auth/calendar,https://www.googleapis.com/auth/spreadsheets}
+      GOOGLE_SHEETS_SCOPES: ${GOOGLE_SHARED_SCOPES:-https://www.googleapis.com/auth/tasks,https://www.googleapis.com/auth/calendar,https://www.googleapis.com/auth/spreadsheets}
+      GOOGLE_CALENDAR_SCOPES: ${GOOGLE_SHARED_SCOPES:-https://www.googleapis.com/auth/tasks,https://www.googleapis.com/auth/calendar,https://www.googleapis.com/auth/spreadsheets}
+    volumes:
+      - mcp-bundle-config:/root/.config/1mcp
+    networks:
+      idc1-stack-net:
+        aliases:
+          - mcp-bundle-assistance
+
+
+  mcp-playwright:
+    <<: *default-service
+    image: mcr.microsoft.com/playwright:v1.58.2-jammy
+    environment:
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+    command:
+      - bash
+      - -lc
+      - |
+        set -e
+        node -v
+        if ! node -e 'require("playwright")' >/dev/null 2>&1; then
+          npm -g i playwright@1.58.2
+        fi
+        if ! node -e 'require("@playwright/mcp")' >/dev/null 2>&1; then
+          npm -g i @playwright/mcp@0.0.68
+        fi
+        CHROMIUM_BIN="$(find /ms-playwright -maxdepth 6 -type f -name chrome -print -quit 2>/dev/null)"
+        if [ -z "$$CHROMIUM_BIN" ]; then
+          echo "missing_chromium_bin"
+          ls -la /ms-playwright 2>/dev/null || true
+          find /ms-playwright -maxdepth 4 -type f -name chrome 2>/dev/null | head -n 20 || true
+          exit 1
+        fi
+        npx @playwright/mcp@0.0.68 --host 0.0.0.0 --port 3050 --no-sandbox --allowed-hosts '*' --allowed-origins '*' --browser chromium --executable-path "$$CHROMIUM_BIN"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sS http://127.0.0.1:3050/ | grep -q 'Invalid request' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  mcp-image-pipeline:
+    <<: *default-service
+    image: ghcr.io/tonezzz/chaba/mcp-image-pipeline:idc1-assistance
+    ports:
+      - "127.0.0.1:3053:3050"
+    environment:
+      ONE_MCP_HOST: 0.0.0.0
+      ONE_MCP_PORT: 3050
+      ONE_MCP_EXTERNAL_URL: ${ONE_MCP_IMAGE_PIPELINE_EXTERNAL_URL:-https://127.0.0.1:3053}
+      ONE_MCP_LOG_LEVEL: info
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      IMAGE_PIPELINE_ASSETS_DIR: ${IMAGE_PIPELINE_ASSETS_DIR:-/data/assets}
+      IMAGE_PIPELINE_MODEL: ${IMAGE_PIPELINE_MODEL:-imagen-4.0-generate-001}
+      IMAGE_PIPELINE_ALLOWED_MODELS: ${IMAGE_PIPELINE_ALLOWED_MODELS:-imagen-4.0-generate-001,imagen-4.0-fast-generate-001,imagen-4.0-ultra-generate-001,gemini-3.1-flash-image-preview}
+    volumes:
+      - image-pipeline-assets:${IMAGE_PIPELINE_ASSETS_DIR:-/data/assets}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3050/health >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  mcp-ws-gateway:
+    <<: *default-service
+    image: node:20-alpine
+    depends_on:
+      - mcp-bundle
+    ports:
+      - "127.0.0.1:18182:8182"
+    working_dir: /app
+    command:
+      - sh
+      - -lc
+      - |
+        set -e
+
+        cat > /app/index.js <<'EOF'
+        const express = require('express');
+        const http = require('http');
+        const crypto = require('crypto');
+        const WebSocket = require('ws');
+
+        const APP_NAME = 'mcp-ws-gateway';
+        const APP_VERSION = '0.1.0';
+
+        const PORT = Number(process.env.PORT || 8182);
+        const WS_PATH = process.env.WS_PATH || '/ws';
+
+        const OPENAI_GATEWAY_URL = (process.env.OPENAI_GATEWAY_URL || 'http://mcp-openai-gateway:8181').replace(/\/$/, '');
+        const MCP_AGENT_URL = (process.env.MCP_AGENT_URL || 'http://mcp-bundle:3050/mcp?app=windsurf').trim();
+
+        function newId(prefix = 'req') {
+          return String(prefix) + '-' + String(Date.now()) + '-' + String(crypto.randomUUID?.() || Math.random().toString(16).slice(2));
+        }
+
+        function safeJsonParse(s) {
+          try {
+            return JSON.parse(s);
+          } catch {
+            return null;
+          }
+        }
+
+        function parseStreamableJsonResponse(bodyText) {
+          const trimmed = (bodyText || '').trim();
+          if (!trimmed) return null;
+
+          if (trimmed.startsWith('{')) {
+            return safeJsonParse(trimmed);
+          }
+
+          const lines = trimmed.split(/\r?\n/);
+          for (const line of lines) {
+            if (line.startsWith('data:')) {
+              const payload = line.replace(/^data:\s*/, '').trim();
+              const obj = safeJsonParse(payload);
+              if (obj) return obj;
+            }
+          }
+          return null;
+        }
+
+        async function mcpInitialize() {
+          const initPayload = {
+            jsonrpc: '2.0',
+            id: '1',
+            method: 'initialize',
+            params: {
+              protocolVersion: '2024-11-05',
+              capabilities: { tools: {}, resources: {}, prompts: {} },
+              clientInfo: { name: APP_NAME, version: APP_VERSION }
+            }
+          };
+
+          const r = await fetch(MCP_AGENT_URL, {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              accept: 'application/json, text/event-stream'
+            },
+            body: JSON.stringify(initPayload)
+          });
+
+          const sessionId = r.headers.get('mcp-session-id');
+          const text = await r.text();
+          const obj = parseStreamableJsonResponse(text);
+          if (!r.ok) {
+            throw new Error('mcp initialize failed: ' + String(r.status) + ' ' + String(text));
+          }
+          if (obj?.error) {
+            throw new Error('mcp initialize error: ' + String(JSON.stringify(obj.error)));
+          }
+          if (!sessionId) {
+            throw new Error('mcp initialize: missing mcp-session-id header');
+          }
+          return sessionId;
+        }
+
+        async function mcpToolsCall(sessionId, toolName, argumentsObj) {
+          const payload = {
+            jsonrpc: '2.0',
+            id: newId('call'),
+            method: 'tools/call',
+            params: { name: toolName, arguments: argumentsObj || {} }
+          };
+
+          const r = await fetch(MCP_AGENT_URL, {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              accept: 'application/json, text/event-stream',
+              'mcp-session-id': sessionId
+            },
+            body: JSON.stringify(payload)
+          });
+
+          const text = await r.text();
+          const obj = parseStreamableJsonResponse(text);
+          if (!r.ok) {
+            throw new Error('mcp tools/call failed: ' + String(r.status) + ' ' + String(text));
+          }
+          return obj;
+        }
+
+        function send(ws, obj) {
+          if (ws.readyState !== WebSocket.OPEN) return;
+          ws.send(JSON.stringify(obj));
+        }
+
+        const app = express();
+        app.use(express.json({ limit: process.env.JSON_BODY_LIMIT || '2mb' }));
+
+        app.get('/health', (_req, res) => {
+          res.json({ ok: true, service: APP_NAME, version: APP_VERSION, wsPath: WS_PATH });
+        });
+
+        const server = http.createServer(app);
+        const wss = new WebSocket.Server({ server, path: WS_PATH });
+
+        wss.on('connection', async (ws) => {
+          const connId = newId('conn');
+          send(ws, { type: 'hello', connId, server: { name: APP_NAME, version: APP_VERSION } });
+
+          const mcpSessionPromise = (async () => {
+            try {
+              const sessionId = await mcpInitialize();
+              send(ws, { type: 'mcp.ready' });
+              return sessionId;
+            } catch (e) {
+              send(ws, { type: 'mcp.error', error: { message: 'MCP init failed: ' + String(e && e.message ? e.message : e) } });
+              return null;
+            }
+          })();
+
+          ws.on('message', async (data) => {
+            const raw = data.toString('utf-8');
+            const msg = safeJsonParse(raw);
+            if (!msg || typeof msg.type !== 'string') {
+              return send(ws, { type: 'error', error: { message: 'Invalid message (expected JSON with type)' } });
+            }
+
+            const requestId = msg.requestId || newId('ws');
+
+            if (msg.type === 'tools.call') {
+              const mcpSessionId = await mcpSessionPromise;
+              if (!mcpSessionId) {
+                return send(ws, { type: 'tools.error', requestId, error: { message: 'MCP not initialized' } });
+              }
+              const toolName = msg.name;
+              if (!toolName) {
+                return send(ws, { type: 'tools.error', requestId, error: { message: 'Missing tool name' } });
+              }
+
+              send(ws, { type: 'tool.start', requestId, name: toolName, arguments: msg.arguments || {} });
+              try {
+                const result = await mcpToolsCall(mcpSessionId, toolName, msg.arguments || {});
+                send(ws, { type: 'tool.done', requestId, name: toolName, result });
+              } catch (e) {
+                send(ws, { type: 'tool.error', requestId, name: toolName, error: { message: e.message } });
+              }
+              return;
+            }
+
+            return send(ws, { type: 'error', requestId, error: { message: 'Unknown message type: ' + String(msg.type) } });
+          });
+        });
+
+        server.listen(PORT, '0.0.0.0', () => {
+          console.log('[' + String(APP_NAME) + '] listening on 0.0.0.0:' + String(PORT));
+        });
+        EOF
+
+        if [ ! -f /app/package.json ]; then
+          npm init -y >/dev/null 2>&1
+        fi
+        if [ ! -d /app/node_modules ]; then
+          npm install --silent express ws
+        fi
+        exec node /app/index.js
+    environment:
+      PORT: 8182
+      WS_PATH: /ws
+      MCP_AGENT_URL: http://mcp-bundle:3050/mcp?app=windsurf
+      OPENAI_GATEWAY_URL: ${OPENAI_GATEWAY_URL:-http://mcp-openai-gateway:8181}
+    volumes:
+      - mcp-ws-gateway-data:/app
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8182/health >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  mcp-ws-gateway-portainer:
+    <<: *default-service
+    image: node:20-alpine
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "127.0.0.1:18183:8182"
+    working_dir: /app
+    command:
+      - sh
+      - -lc
+      - |
+        set -e
+
+        cat > /app/index.js <<'EOF'
+        const express = require('express');
+        const http = require('http');
+        const crypto = require('crypto');
+        const WebSocket = require('ws');
+
+        const APP_NAME = 'mcp-ws-gateway';
+        const APP_VERSION = '0.1.0';
+
+        const PORT = Number(process.env.PORT || 8182);
+        const WS_PATH = process.env.WS_PATH || '/ws';
+
+        function newId(prefix = 'req') {
+          return String(prefix) + '-' + String(Date.now()) + '-' + String(crypto.randomUUID?.() || Math.random().toString(16).slice(2));
+        }
+
+        function safeJsonParse(s) {
+          try {
+            return JSON.parse(s);
+          } catch {
+            return null;
+          }
+        }
+
+        function send(ws, obj) {
+          if (ws.readyState !== WebSocket.OPEN) return;
+          ws.send(JSON.stringify(obj));
+        }
+
+        const app = express();
+        app.use(express.json({ limit: process.env.JSON_BODY_LIMIT || '2mb' }));
+
+        app.get('/health', (_req, res) => {
+          res.json({ ok: true, service: APP_NAME, version: APP_VERSION, wsPath: WS_PATH });
+        });
+
+        const server = http.createServer(app);
+        const wss = new WebSocket.Server({ server, path: WS_PATH });
+
+        wss.on('connection', async (ws) => {
+          const connId = newId('conn');
+          send(ws, { type: 'hello', connId, server: { name: APP_NAME, version: APP_VERSION } });
+        });
+
+        server.listen(PORT, '0.0.0.0', () => {
+          console.log('[' + String(APP_NAME) + '] listening on 0.0.0.0:' + String(PORT));
+        });
+        EOF
+
+        if [ ! -f /app/package.json ]; then
+          npm init -y >/dev/null 2>&1
+        fi
+        if [ ! -d /app/node_modules ]; then
+          npm install --silent express ws
+        fi
+        exec node /app/index.js
+    environment:
+      PORT: 8182
+      WS_PATH: /ws
+      MCP_AGENT_URL: http://host.docker.internal:3051/mcp?app=windsurf
+      OPENAI_GATEWAY_URL: ${OPENAI_GATEWAY_URL:-http://mcp-openai-gateway:8181}
+    volumes:
+      - mcp-ws-gateway-portainer-data:/app
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8182/health >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+networks:
+  idc1-stack-net:
+    driver: bridge
+    external: true
+    name: idc1-stack-net
+
+volumes:
+  mcp-bundle-config:
+    external: true
+    name: ${MCP_BUNDLE_CONFIG_VOLUME_NAME:-idc1-assistance_mcp-bundle-config}
+
+  image-pipeline-assets:
+    external: true
+    name: ${IMAGE_PIPELINE_ASSETS_VOLUME_NAME:-idc1-assistance_image-pipeline-assets}
+
+  mcp-ws-gateway-data:
+    external: true
+    name: ${MCP_WS_GATEWAY_DATA_VOLUME_NAME:-idc1-assistance_mcp-ws-gateway-data}
+
+  mcp-ws-gateway-portainer-data:
+    external: true
+    name: ${MCP_WS_GATEWAY_PORTAINER_DATA_VOLUME_NAME:-idc1-assistance_mcp-ws-gateway-portainer-data}

--- a/stacks/idc1-assistance-workers/docker-compose.yml
+++ b/stacks/idc1-assistance-workers/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.9"
+
+x-default-service: &default-service
+  restart: unless-stopped
+  env_file:
+    - ../idc1-assistance/.env.example
+  networks:
+    - idc1-stack-net
+  logging:
+    driver: "json-file"
+    options:
+      max-size: "10m"
+      max-file: "3"
+
+services:
+  deep-research-worker:
+    <<: *default-service
+    image: ghcr.io/tonezzz/chaba/deep-research-worker:idc1-assistance
+    ports:
+      - "127.0.0.1:18030:8030"
+    environment:
+      PORT: 8030
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      DEEP_RESEARCH_AGENT: ${DEEP_RESEARCH_AGENT:-deep-research-pro-preview-12-2025}
+      DEEP_RESEARCH_DB: ${DEEP_RESEARCH_DB:-/data/deep_research.sqlite}
+      DEEP_RESEARCH_POLL_SECONDS: ${DEEP_RESEARCH_POLL_SECONDS:-10}
+    volumes:
+      - deep-research-worker-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8030/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+networks:
+  idc1-stack-net:
+    driver: bridge
+    external: true
+    name: idc1-stack-net
+
+volumes:
+  deep-research-worker-data:
+    external: true
+    name: ${DEEP_RESEARCH_WORKER_DATA_VOLUME_NAME:-idc1-assistance_deep-research-worker-data}

--- a/stacks/idc1-assistance/docker-compose.yml
+++ b/stacks/idc1-assistance/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     environment:
       ONE_MCP_HOST: 0.0.0.0
       ONE_MCP_PORT: 3050
-      ONE_MCP_EXTERNAL_URL: http://127.0.0.1:3051
+      ONE_MCP_EXTERNAL_URL: ${ONE_MCP_EXTERNAL_URL:-https://127.0.0.1:3051}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
       GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI:-}
@@ -2233,7 +2233,7 @@ services:
     environment:
       ONE_MCP_HOST: 0.0.0.0
       ONE_MCP_PORT: 3050
-      ONE_MCP_EXTERNAL_URL: http://127.0.0.1:3053
+      ONE_MCP_EXTERNAL_URL: ${ONE_MCP_IMAGE_PIPELINE_EXTERNAL_URL:-https://127.0.0.1:3053}
       ONE_MCP_LOG_LEVEL: info
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       IMAGE_PIPELINE_ASSETS_DIR: ${IMAGE_PIPELINE_ASSETS_DIR:-/data/assets}
@@ -2274,7 +2274,7 @@ services:
         const WS_PATH = process.env.WS_PATH || '/ws';
         
         const OPENAI_GATEWAY_URL = (process.env.OPENAI_GATEWAY_URL || 'http://mcp-openai-gateway:8181').replace(/\/$/, '');
-        const MCP_AGENT_URL = (process.env.MCP_AGENT_URL || 'http://1mcp-agent:3051/mcp?app=windsurf').trim();
+        const MCP_AGENT_URL = (process.env.MCP_AGENT_URL || 'http://mcp-bundle:3050/mcp?app=windsurf').trim();
         
         function newId(prefix = 'req') {
           return String(prefix) + '-' + String(Date.now()) + '-' + String(crypto.randomUUID?.() || Math.random().toString(16).slice(2));
@@ -2589,7 +2589,7 @@ services:
         const WS_PATH = process.env.WS_PATH || '/ws';
         
         const OPENAI_GATEWAY_URL = (process.env.OPENAI_GATEWAY_URL || 'http://mcp-openai-gateway:8181').replace(/\/$/, '');
-        const MCP_AGENT_URL = (process.env.MCP_AGENT_URL || 'http://1mcp-agent:3051/mcp?app=windsurf').trim();
+        const MCP_AGENT_URL = (process.env.MCP_AGENT_URL || 'http://mcp-bundle:3050/mcp?app=windsurf').trim();
         
         function newId(prefix = 'req') {
           return String(prefix) + '-' + String(Date.now()) + '-' + String(crypto.randomUUID?.() || Math.random().toString(16).slice(2));
@@ -2867,7 +2867,7 @@ services:
     environment:
       PORT: 8182
       WS_PATH: /ws
-      MCP_AGENT_URL: http://host.docker.internal:3052/mcp?app=windsurf
+      MCP_AGENT_URL: http://host.docker.internal:3051/mcp?app=windsurf
       OPENAI_GATEWAY_URL: ${OPENAI_GATEWAY_URL:-http://mcp-openai-gateway:8181}
     volumes:
       - mcp-ws-gateway-portainer-data:/app


### PR DESCRIPTION
- Split compose into Core / Workers / Infra / MCP stacks\n- Refactor mcp-bundle image to use embedded entrypoint (no inline compose command)\n- Align MCP external URLs to HTTPS defaults and fix ws-gateway MCP_AGENT_URL targets\n\nFollow-up: create 4 Portainer Git-backed stacks pointing at split compose files and redeploy.