### PR TITLE
Jarvis: fix showDebugLogsRef crash

### DIFF
--- a/services/assistance/jarvis-frontend/App.tsx
+++ b/services/assistance/jarvis-frontend/App.tsx
@@ -35,6 +35,7 @@ export default function App() {
   });
   const [expandedLogId, setExpandedLogId] = useState<string | null>(null);
   const [showDebugLogs, setShowDebugLogs] = useState(false);
+  const showDebugLogsRef = useRef<boolean>(false);
   const liveService = useRef<LiveService | null>(null);
   const [activeMedia, setActiveMedia] = useState<MessageLog | null>(null);
   const [isTalking, setIsTalking] = useState(false);


### PR DESCRIPTION
Fix frontend runtime crash: showDebugLogsRef was referenced in App.tsx autospeak gating but never initialized. Add the missing useRef<boolean>(false) so production bundle no longer throws ReferenceError.