### PR TITLE
docs: Jarvis routing + resume + news tuning SSOT

### DIFF
--- a/services/assistance/docs/CONFIG.md
+++ b/services/assistance/docs/CONFIG.md
@@ -56,6 +56,11 @@ Notes:
   - public: `https://assistance.idc1.surf-thailand.com/jarvis/api/...`
   - proxy behavior: `handle_path /jarvis/api/*` -> `http://127.0.0.1:18018` (strip `/jarvis/api`)
 
+WebSocket:
+
+- public: `wss://assistance.idc1.surf-thailand.com/jarvis/ws/live`
+- backend internal: `/ws/live` (edge proxy strips `/jarvis/ws` before proxying)
+
 Public examples (when edge proxy is configured):
 
 ```bash

--- a/services/assistance/docs/OVERVIEW.md
+++ b/services/assistance/docs/OVERVIEW.md
@@ -24,7 +24,7 @@ Out of scope:
 
 ```mermaid
 graph TD
-  UI[Jarvis UI] -->|WS /ws/live| BE[jarvis-backend]
+  UI[Jarvis UI] -->|WS /jarvis/ws/live| BE[jarvis-backend]
   UI -->|HTTP /jarvis/api/*| BE
   BE -->|HTTP| MCP[1MCP / MCP gateway]
   BE -->|HTTP| GH[GitHub API]

--- a/services/assistance/docs/SYSTEM.md
+++ b/services/assistance/docs/SYSTEM.md
@@ -43,6 +43,33 @@ Routing can be enabled/disabled by:
 
 Operator procedure (update → reload → verify): `services/assistance/docs/ACTION.md`.
 
+## Adaptive news tuning (SSOT-first)
+
+Goal:
+
+- Keep `news_topics` / `news_sources` as the SSOT for the news system.
+- Allow Jarvis to improve topics/sources based on usage, without silent writes.
+
+Approach:
+
+- Observe usage signals (e.g. `current_news_get`, topic details opens, refresh frequency, explicit feedback phrases).
+- Generate *suggestions* (sheet diffs) for:
+  - `news_topics` keyword tweaks / new topics
+  - `news_sources` enable/disable, weights/throttles
+- Present suggestions as a **Pending confirmation** item.
+- Only write to Sheets after explicit user confirmation.
+
+Skills Sheet integration (minimum hardcode):
+
+- Add skills rows that map natural language like "improve news topics" / "ข่าวนี้ไม่เกี่ยว" to deterministic tool calls:
+  - `news_tuning_suggest` (no writes)
+  - `news_tuning_apply` (writes after confirmation)
+
+Notes:
+
+- Auto-create is allowed, but should be created as *disabled* until confirmed.
+- The sheet remains authoritative; SQLite/runtime state stores only derived metrics (usage stats, cache metadata).
+
 ## System KV keys
 
 ### `system.sheets` (required)

--- a/services/assistance/docs/TOOLS.md
+++ b/services/assistance/docs/TOOLS.md
@@ -358,8 +358,8 @@ The frontend has a voice UX fallback that can auto-trigger deterministic WS tool
 
 This routing is now configurable via sys sheet keys and exposed via HTTP:
 
-- `GET /jarvis/config/voice_commands` (when reverse-proxied under `/jarvis`)
-- `GET /config/voice_commands` (direct backend)
+- Public (recommended): `GET /jarvis/api/config/voice_commands`
+- Direct backend (dev / internal): `GET /config/voice_commands`
 
 Response:
 
@@ -380,10 +380,38 @@ Supported sys kv keys (defaults shown):
 - `voice_cmd.reminders_add.phrases=` (optional)
 - `voice_cmd.gems_list.enabled=true`
 - `voice_cmd.gems_list.phrases=` (optional)
+- `voice_cmd.recent_activity.enabled=true`
+- `voice_cmd.recent_activity.phrases=recent tasks,recent activity,what was i doing,เมื่อกี้ทำอะไร,งานล่าสุด,...`
 
 To apply sys sheet changes:
 
 - Use `system.reload` (or wait for the backend to reload sheet caches).
+
+## WS: readiness phases (backend-driven)
+
+On WS connect the backend emits compact readiness events:
+
+- `type=readiness phase=transport_connected`
+- `type=readiness phase=bootstrap_ready`
+- `type=readiness phase=context_cached`
+- `type=readiness phase=model_ready`
+- `type=readiness phase=model_disconnected`
+
+The frontend uses these phases for:
+
+- header readiness indicator + elapsed time
+- gating autospeak triggers until `model_ready`
+
+## WS: session resume payload
+
+On WS connect the backend emits `type=session_resume` with recent dialog turns.
+
+Resume limits are configurable via env:
+
+- `JARVIS_RESUME_WINDOW_SECONDS` (default `2700` = 45m), anchored to the newest stored turn
+- `JARVIS_RESUME_MAX_TURNS` (default `10`)
+- `JARVIS_RESUME_MAX_CHARS` (default `1200`)
+- `JARVIS_RESUME_FILTER_COMMAND_LIKE` (default `true`)
 
 ### Tool chart: notes.*
 


### PR DESCRIPTION
Update Assistance/Jarvis docs:
- Canonical public routing: HTTP /jarvis/api/*, WS /jarvis/ws/live
- Voice command config endpoint: /jarvis/api/config/voice_commands
- Document readiness phases + session_resume limits
- Add SSOT-first adaptive news tuning plan driven by Skills Sheet (suggest -> pending confirm -> apply)